### PR TITLE
Support date times in date fields

### DIFF
--- a/src/interop.rs
+++ b/src/interop.rs
@@ -58,33 +58,31 @@ impl From<&tex::Person> for Person {
 
 impl From<tex::Date> for Date {
     fn from(date: tex::Date) -> Self {
-        match date.value {
-            DateValue::At(x)
-            | DateValue::After(x)
-            | DateValue::Before(x)
-            | DateValue::Between(_, x) => {
-                let (hour, minute, second, nanosecond) = x
-                    .time
-                    .map(|time| {
-                        (
-                            Some(time.hour() as _),
-                            Some(time.minute() as _),
-                            Some(time.second() as _),
-                            Some(time.nanosecond()),
-                        )
-                    })
-                    .unwrap_or_default();
-                Self {
-                    year: x.year,
-                    month: x.month,
-                    day: x.day,
-                    hour,
-                    minute,
-                    second,
-                    nanosecond,
-                    offset: None,
-                }
-            }
+        let (DateValue::At(x)
+        | DateValue::After(x)
+        | DateValue::Before(x)
+        | DateValue::Between(_, x)) = date.value;
+        let (hour, minute, second, nanosecond) = x
+            .time
+            .map(|time| {
+                (
+                    Some(time.hour() as _),
+                    Some(time.minute() as _),
+                    Some(time.second() as _),
+                    Some(time.nanosecond()),
+                )
+            })
+            .unwrap_or_default();
+
+        Self {
+            year: x.year,
+            month: x.month,
+            day: x.day,
+            hour,
+            minute,
+            second,
+            nanosecond,
+            offset: None,
         }
     }
 }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -3,6 +3,7 @@
 use std::convert::TryFrom;
 
 use biblatex as tex;
+use chrono::Timelike as _;
 use tex::{
     Chunk, ChunksExt, DateValue, Edition, EditorType, RetrievalError, Spanned, TypeError,
 };
@@ -58,10 +59,32 @@ impl From<&tex::Person> for Person {
 impl From<tex::Date> for Date {
     fn from(date: tex::Date) -> Self {
         match date.value {
-            DateValue::At(x) | DateValue::After(x) | DateValue::Before(x) => {
-                Date { year: x.year, month: x.month, day: x.day }
+            DateValue::At(x)
+            | DateValue::After(x)
+            | DateValue::Before(x)
+            | DateValue::Between(_, x) => {
+                let (hour, minute, second, nanosecond) = x
+                    .time
+                    .map(|time| {
+                        (
+                            Some(time.hour() as _),
+                            Some(time.minute() as _),
+                            Some(time.second() as _),
+                            Some(time.nanosecond()),
+                        )
+                    })
+                    .unwrap_or_default();
+                Self {
+                year: x.year,
+                month: x.month,
+                day: x.day,
+                    hour,
+                    minute,
+                    second,
+                    nanosecond,
+                offset: None,
+                }
             }
-            DateValue::Between(_, x) => Self { year: x.year, month: x.month, day: x.day },
         }
     }
 }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -75,14 +75,14 @@ impl From<tex::Date> for Date {
                     })
                     .unwrap_or_default();
                 Self {
-                year: x.year,
-                month: x.month,
-                day: x.day,
+                    year: x.year,
+                    month: x.month,
+                    day: x.day,
                     hour,
                     minute,
                     second,
                     nanosecond,
-                offset: None,
+                    offset: None,
                 }
             }
         }

--- a/src/io.rs
+++ b/src/io.rs
@@ -771,18 +771,7 @@ fn entry_from_yaml(
 
 impl From<Date> for Yaml {
     fn from(date: Date) -> Self {
-        let s = match (date.month.is_some(), date.day.is_some()) {
-            (true, true) => format!(
-                "{:04}-{:02}-{:02}",
-                date.year,
-                date.month.unwrap() + 1,
-                date.day.unwrap() + 1,
-            ),
-            (true, false) => format!("{:04}-{:02}", date.year, date.month.unwrap() + 1),
-            (false, _) => return Yaml::Integer(date.year as i64),
-        };
-
-        Yaml::String(s)
+        Yaml::String(date.to_string())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,6 +630,7 @@ mod tests {
             "swedish",
             "latex-users",
             "barb",
+            "cat"
         ]);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -539,6 +539,58 @@ pub enum DateError {
     OffsetOutOfBounds,
 }
 
+impl Display for Date {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Date {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            nanosecond,
+            offset,
+        } = self;
+        write!(f, "{year:04}")?;
+
+        if let Some(month) = month {
+            let month = month + 1;
+            write!(f, "-{month:02}")?;
+        } else {
+            return Ok(());
+        }
+
+        if let Some(day) = day {
+            let day = day + 1;
+            write!(f, "-{day:02}")?;
+        } else {
+            return Ok(());
+        }
+
+        if let Some(hour) = hour {
+            write!(f, "T{hour:02}")?;
+        } else {
+            return Ok(());
+        }
+
+        if let Some(minute) = minute {
+            write!(f, ":{minute:02}")?;
+            if let Some(second) = second {
+                write!(f, ":{second:02}")?;
+                if let Some(nanosecond) = nanosecond {
+                    write!(f, ".{nanosecond:09}")?;
+                }
+            }
+        }
+
+        if let Some(offset) = offset {
+            write!(f, "{offset}")?;
+        }
+
+        Ok(())
+    }
+}
+
 impl FromStr for Date {
     type Err = DateError;
 
@@ -1093,10 +1145,9 @@ impl_try_from_value!(Entries, Vec<Entry>, [Entry]);
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr as _;
+    use super::{Date, Person};
     use chrono::FixedOffset;
-
-    use super::{Person, Date};
+    use std::str::FromStr as _;
 
     #[test]
     fn person_initials() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,10 +28,6 @@ lazy_static! {
     // Duration regexes.
     static ref DURATION_REGEX: Regex = Regex::new(r"^(((?P<d>\d+)\s*:\s*)?(?P<h>\d{2,})\s*:\s*)?(?P<m>\d{2,})\s*:\s*(?P<s>\d{2})(\s*,\s*(?P<ms>\d+))?").unwrap();
     static ref DURATION_RANGE_REGEX: Regex = Regex::new(r"^(?P<s>((\d+\s*:\s*)?\d{2,}\s*:\s*)?\d{2,}\s*:\s*\d{2}(\s*,\s*\d+)?)(\s*-+\s*(?P<e>((\d+\s*:\s*)?\d{2,}\s*:\s*)?\d{2,}\s*:\s*\d{2}(\s*,\s*\d+)?))?").unwrap();
-
-    // Definite (i. e. non-range) date regexes.
-    static ref MONTH_REGEX: Regex = Regex::new(r"^(?P<y>(\+|-)?\s*\d{4})\s*-\s*(?P<m>\d{2})").unwrap();
-    static ref YEAR_REGEX: Regex = Regex::new(r"^(?P<y>(\+|-)?\s*\d{4})").unwrap();
 }
 
 /// Describes which kind of work a database entry refers to.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1049,7 +1049,8 @@ impl_try_from_value!(Entries, Vec<Entry>, [Entry]);
 
 #[cfg(test)]
 mod tests {
-    use super::Person;
+    use std::str::FromStr as _;
+    use super::{Person, Date};
 
     #[test]
     fn person_initials() {
@@ -1057,5 +1058,15 @@ mod tests {
         assert_eq!("C. D.", p.initials(Some(".")).unwrap());
         let p = Person::from_strings(&["Günther", "Hans-Joseph"]).unwrap();
         assert_eq!("H-J", p.initials(None).unwrap());
+    }
+
+    #[test]
+    fn date_from_str() {
+        assert_eq!(Date { year: 1994, month: None, day: None }, Date::from_str("1994").unwrap());
+        assert_eq!(Date { year: 1994, month: Some(8), day: None }, Date::from_str("1994-09").unwrap());
+        assert_eq!(Date { year: 1994, month: Some(8), day: Some(12) }, Date::from_str("1994-09-13").unwrap());
+
+        // This seems like a weird artifact of the current implementation
+        assert_eq!(Date { year: 1994, month: None, day: None }, Date::from_str("19  94").unwrap());
     }
 }

--- a/tests/basic.yml
+++ b/tests/basic.yml
@@ -399,3 +399,9 @@ barb:
     publisher: MVG
     location: München
     language: de-DE
+
+cat:
+    type: Article
+    title: The Cathedral and the Bazaar
+    author: Raymond, Eric Steven
+    date: 2002-08-02T09:02:14.123456789Z


### PR DESCRIPTION
This PR supports RFC3339 formatted datetimes in date fields. The datetimes are read and stored with maximum available precision.

The following points could still be addressed: 

* [ ] With the current implementation the string "19 94" is parsed as "1994". Should this be fixed?
* [x] Roundtrips are not fully idempotent: the offset `Z` turns into `+00:00`.
* [ ] The tests are relatively limited, perhaps property-based tests could be implemented to improve this.
* [x] Dates could also support conversion from/to YAML hashes.

Technically, this is a breaking change, since the `Date` struct got new fields. For the future, this could be fixed by adding `#[non_exhaustive]` to the struct definition.

Fixes #30.

