### PR TITLE
Supplements in Alphanumeric and AuthorTitle style

### DIFF
--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -1118,6 +1118,11 @@ impl<'a> CitationStyle<'a> for Alphanumerical {
             let record = db.records.get_mut(atomic.entry.key()).unwrap();
             record.prefix = Some(res.clone());
 
+            if let Some(supplement) = atomic.supplement {
+                res += ", ";
+                res += supplement;
+            }
+
             items.push(res);
         }
 
@@ -1200,6 +1205,11 @@ impl<'a> CitationStyle<'a> for AuthorTitle {
                 res += "(";
                 res += Language::from_639_1(lang.language.as_str()).unwrap().to_name();
                 res += ")";
+            }
+
+            if let Some(supplement) = atomic.supplement {
+                push_comma_quote_aware(&mut res.value, ',', true);
+                res += supplement;
             }
 
             items.push(res);


### PR DESCRIPTION
Fixes #48 (and by extension, https://github.com/typst/typst/issues/1330).

Now this:
```rb
#set cite(style: "alphanumerical")
@Zeltner2021[p.~7]
```
generates

```diff
-[Zel+21]
+[Zel+21, p. 7]
```

and this:

```rb
#set cite(style: "chicago-author-title")
@Zeltner2021[p.~7].
```
generates

```diff
-Zeltner et al., “Monte Carlo Estimators for Differential Light Transport”
+Zeltner et al., “Monte Carlo Estimators for Differential Light Transport,” p. 7
```
