### PR TITLE
Fix missing container for type anthos (#72)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,6 +741,12 @@ impl Entry {
                 EntryType::Reference,
                 EntryType::Web,
             ]),
+            EntryType::Anthos => retrieve_container(&[
+                EntryType::Book,
+                EntryType::Anthology,
+                EntryType::Reference,
+                EntryType::Report,
+            ]),
             EntryType::Chapter => retrieve_container(&[
                 EntryType::Book,
                 EntryType::Anthology,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,9 +735,11 @@ impl Entry {
         match &self.entry_type {
             EntryType::Article => retrieve_container(&[
                 EntryType::Book,
+                EntryType::Conference,
                 EntryType::Periodical,
                 EntryType::Newspaper,
                 EntryType::Blog,
+                EntryType::Proceedings,
                 EntryType::Reference,
                 EntryType::Web,
             ]),


### PR DESCRIPTION
I've run the following commands for testing. Is that the correct test workflow?

```bash
cargo build --features cli
./target/debug/hayagriva apatest.bib reference --style apa
```

Now the output is as expected.

> Alloy, L.B., Kelly, K., Mineka, et al. (1990). inbook: Comorbidity of anxiety and depressive disorders: A helplessness-hopelessness perspective. In J. Maser & C. Cloninger (Eds.), Comorbidity of mood and anxiety disorders (pp. 499–543). American Psychiatric Press.
> Alloy, L.B., Kelly, K., Mineka, et al. (1990). incollection: Comorbidity of anxiety and depressive disorders: A helplessness-hopelessness perspective. In J. Maser & C. Cloninger (Eds.), Comorbidity of mood and anxiety disorders (pp. 499–543). American Psychiatric Press.
