### PR TITLE
fix volume reference

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -194,6 +194,7 @@ impl EntryLike for Entry {
             NumberVariable::Volume => self
                 .get_container()
                 .and_then(|e| e.volume())
+                .or_else(|| self.volume())
                 .map(MaybeTyped::to_cow),
         }
     }

--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -191,7 +191,10 @@ impl EntryLike for Entry {
                         .map(|n| MaybeTyped::Typed(Cow::Owned(n)))
                         .unwrap_or_else(|_| MaybeTyped::String(s.to_owned()))
                 }),
-            NumberVariable::Volume => self.volume().map(MaybeTyped::to_cow),
+            NumberVariable::Volume => self
+                .get_container()
+                .and_then(|e| e.volume())
+                .map(MaybeTyped::to_cow),
         }
     }
 


### PR DESCRIPTION
This implements a fix suggested entirely by @zepinglee 

The issue, which is described in more detail below, is that hayagriva fails to find the volume when it is stored in the articles parent. 
https://github.com/typst/typst/issues/2643