### PR TITLE
Fix Pulling Punctuattion into Quotation marks

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -2279,6 +2279,16 @@ impl<'a, T: EntryLike> Context<'a, T> {
                     .and_then(|p| p.0.last_mut())
                 {
                     Some(ElemChild::Text(f)) => &mut f.text,
+                    // Get the text element if it is contained in an `Elem`.
+                    Some(ElemChild::Elem(Elem { children, .. }))
+                        if children.0.len() == 1
+                            && matches!(children.0[0], ElemChild::Text(_)) =>
+                    {
+                        match &mut children.0[0] {
+                            ElemChild::Text(f) => &mut f.text,
+                            _ => unreachable!(),
+                        }
+                    }
                     _ => {
                         used_buf = true;
                         self.writing.buf.as_string_mut()


### PR DESCRIPTION
Fix #85.

The issue is that in some instances (such as in #85), the quotes are not in a `Text` but another `Elem`.

My solution to this also considers `Text` if it is the only child of a surrounding `Elem`.

Since I don't know the architecture well, my hack might be supoptimal. Perhaps a `flatten` function on `ElementChild` makes more sense?

Also: How do you want me to add a test for this?