### PR TITLE
Update `strum` to eliminate `syn1`-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ url = { version =  "2.4", features = ["serde"] }
 biblatex = { version = "0.9", optional = true }
 ciborium = { version = "0.2.1", optional = true }
 clap = { version = "3.1", optional = true, features = ["cargo"] }
-strum = { version = "0.24", features = ["derive"], optional = true }
+strum = { version = "0.25", features = ["derive"], optional = true }
 
 [dev-dependencies]
 heck = "0.4"


### PR DESCRIPTION
This is the end!

- [x] `comemo` has been updated to use `syn2`
- [x] `biblatex`-parser crate has been updated.
- [x] `biblatex` has to be _published_, and the new version should be added to `hayagriva` once that happens
- [x] this PR updates `strum` to latest version, that uses `syn2`. 
  
This will ensure that typst/typst doesn't have `syn1` in its dependency tree anywhere, and should thus yield compile time improvement.