### PR TITLE
Fix editor reference (#94)

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -409,7 +409,13 @@ impl EntryLike for Entry {
                     "p",
                 )
                 .map(|e| e.affiliated_with_role(PersonRole::Director)),
-            NameVariable::Editor => self.editors().map(|a| a.iter().collect()),
+            NameVariable::Editor => {
+                self.editors().map(|a| a.iter().collect()).or_else(|| {
+                    self.get_container()
+                        .and_then(|e| e.editors())
+                        .map(|a| a.iter().collect())
+                })
+            }
             NameVariable::EditorialDirector => None,
             NameVariable::EditorTranslator => {
                 let translator = self.affiliated_with_role(PersonRole::Translator);


### PR DESCRIPTION
The modify version of hayagriva tries to find the `editor` of the entry's container if it doesn't have `editor` itself. This is inspired by <https://github.com/typst/hayagriva/pull/82#discussion_r1397018367>.