### PR TITLE
Add abstract, annote, and genre fieldss

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -209,8 +209,13 @@ impl EntryLike for Entry {
     ) -> Option<Cow<'_, ChunkedString>> {
         let entry = self;
         match variable {
-            StandardVariable::Abstract => None,
-            StandardVariable::Annote => None,
+            StandardVariable::Abstract => entry
+                .map(|e| e.abstract_())
+                .map(|f| f.select(form))
+                .map(Cow::Borrowed),
+            StandardVariable::Annote => {
+                entry.map(|e| e.annote()).map(|f| f.select(form)).map(Cow::Borrowed)
+            }
             StandardVariable::Archive => {
                 entry.map(|e| e.archive()).map(|f| f.select(form)).map(Cow::Borrowed)
             }
@@ -264,7 +269,9 @@ impl EntryLike for Entry {
                 .and_then(Entry::location)
                 .map(|f| f.select(form))
                 .map(Cow::Borrowed),
-            StandardVariable::Genre => None,
+            StandardVariable::Genre => {
+                entry.map(|e| e.genre()).map(|f| f.select(form)).map(Cow::Borrowed)
+            }
             StandardVariable::ISBN => {
                 entry.isbn().map(|d| Cow::Owned(StringChunk::verbatim(d).into()))
             }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -524,6 +524,14 @@ impl TryFrom<&tex::Entry> for Entry {
             }
         }
 
+        if let Some(abstract_) = map_res(entry.abstract_())? {
+            item.set_abstract_(abstract_.into())
+        }
+
+        if let Some(annote) = map_res(entry.annotation())? {
+            item.set_annote(annote.into())
+        }
+
         if let Some(series) = map_res(entry.series())? {
             let title: FormatString = series.into();
             let mut new = Entry::new(&entry.key, item.entry_type);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,6 +545,18 @@ entry! {
     "call-number" => call_number: FormatString,
     /// Additional description to be appended in the bibliographic entry.
     "note" => note: FormatString,
+    /// Abstract of the item (e.g. the abstract of a journal article).
+    "abstract" => abstract_: FormatString,
+    /// Short markup, decoration, or annotation to the item (e.g., to indicate
+    /// items included in a review);
+    ///
+    /// For descriptive text (e.g., in an annotated bibliography), use `note`
+    /// instead.
+    "annote" => annote: FormatString,
+    /// Type, class, or subtype of the item (e.g. “Doctoral dissertation” for
+    /// a PhD thesis; “NIH Publication” for an NIH technical report);
+    /// Do not use for topical descriptions or categories (e.g. “adventure” for an adventure movie).
+    "genre" => genre: FormatString,
 }
 
 impl Entry {


### PR DESCRIPTION
This PR adds three fields, abstract, annote, and genre; all as `FormatableString`.

The first two are also extracted from the BibLaTeX input if present. The genre field, seemingly, has no equivalent in bib files.

This will close #101.

Let me know if I should change something or add more fields. Most other fields that are still missing seem more complex and require discussion how hayagriva should manage them.