### PR TITLE
Fix Issue #103

### DIFF
--- a/src/types/numeric.rs
+++ b/src/types/numeric.rs
@@ -378,7 +378,8 @@ impl NumericValue {
     /// Returns a range if the value is a range.
     pub fn range(&self) -> Option<std::ops::Range<i32>> {
         match self {
-            Self::Number(_) => None,
+            // A single number is seen as a range of length 1. See #103.
+            Self::Number(n) => Some(*n..(*n + 1)),
             Self::Set(vec) => {
                 if vec.len() == 2 {
                     let start = vec[0].0;


### PR DESCRIPTION
Fix #103.

Changes the `NumericValue::range` method to return a range for a single number.