### PR TITLE
Fix Issue #122

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -347,8 +347,7 @@ impl<'a, T: EntryLike + Hash + PartialEq + Eq + Debug> BibliographyDriver<'a, T>
                 );
 
                 //     - Add final locator
-                res[i].items[j].cite_props.speculative.locator =
-                    mem::take(&mut res[i].items[j].locator);
+                res[i].items[j].cite_props.speculative.locator = res[i].items[j].locator;
             }
         }
 


### PR DESCRIPTION
Changed `BibliographyDriver::finish` to not _take_ the locator from the speculative items. That lead to the locator of `last` to always be `None`, which caused #122.

Does anyone know why the `take` was there?

Fixes #122.