### PR TITLE
Fix citation suppresses title when no author provided

### DIFF
--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -774,16 +774,17 @@ fn choose_children<F, R, T: EntryLike>(
 where
     F: FnMut(&[LayoutRenderingElement], &mut Context<T>) -> R,
 {
-    for branch in choose.branches() {
-        if branch.match_.test(BranchConditionIter::from_branch(branch, ctx)) {
-            return Some(f(&branch.children, ctx));
-        }
-    }
+    let supressed = ctx.writing.suppress_queried_variables;
+    ctx.writing.stop_suppressing_queried_variables();
+    let branch = choose
+        .branches()
+        .find(|branch| branch.match_.test(BranchConditionIter::from_branch(branch, ctx)));
+    ctx.writing.suppress_queried_variables = supressed;
 
-    choose
-        .otherwise
-        .as_ref()
-        .map(|fallthrough| f(&fallthrough.children, ctx))
+    branch
+        .map(|b| b.children.as_slice())
+        .or_else(|| choose.otherwise.as_ref().map(|f| f.children.as_slice()))
+        .map(|children| f(children, ctx))
 }
 
 impl RenderCsl for citationberg::Choose {


### PR DESCRIPTION
From https://github.com/typst/citationberg/issues/4#issuecomment-2009709750
> I found the problem is due to `substitute` and `choose` working together. (Its actually a problem of `typst/hayagriva`)
> 
>    1. `substitute` will cause any subsequent `query` to variables, in this case, the `title`, suppressed if that variable is queried once before.
> 
>    2. `choose` actually calls `query` to `title`  two times, the first time to find out which branch makes sense and the second to render.
> 
>    3. therefore the second time is suppressed and resulting in no title.
> 
> 
> A simple fix can be to do a silent lookup on the first `query` of `choose`, much like what is done in `Test::will_have_info(..)`.
> 
> This is the output from OP's bib after applying the fix:
> 
> ```
> Definition and objectives of systems development. (2016, January 19). https://www.opentextbooks.org.hk/ditatopic/25323
> ```
> 
> However, the `journal` part does not seem to be there, which I think is not there even with author specified.

Fixes typst/citationberg#4
Fixes #139 

