### PR TITLE
Fix #142

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ archive = ["ciborium"]
 csl-json = ["citationberg/json"]
 
 [dependencies]
-citationberg = "0.3.0"
+citationberg = { git = "https://github.com/typst/citationberg.git" }
 indexmap = { version = "2.0.2", features = ["serde"] }
 numerals = "0.1.4"
 paste = "1.0.14"
@@ -27,7 +27,7 @@ thiserror = "1.0.48"
 unic-langid = { version = "0.9.0", features = ["serde"] }
 unicode-segmentation = "1.6.0"
 unscanny = "0.1.0"
-url = { version =  "2.4", features = ["serde"] }
+url = { version = "2.4", features = ["serde"] }
 biblatex = { version = "0.9", optional = true }
 ciborium = { version = "0.2.1", optional = true }
 clap = { version = "4", optional = true, features = ["cargo"] }

--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -365,7 +365,10 @@ fn render_typed_num<T: EntryLike>(
     }
 }
 
-fn render_page_range<T: EntryLike>(range: std::ops::Range<i32>, ctx: &mut Context<T>) {
+fn render_page_range<T: EntryLike>(
+    range: std::ops::RangeInclusive<i32>,
+    ctx: &mut Context<T>,
+) {
     ctx.style
         .csl
         .settings

--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -164,7 +164,7 @@ impl EntryLike for Entry {
                     MaybeTyped::Typed(r) => r.range(),
                     MaybeTyped::String(_) => None,
                 })
-                .map(|r| MaybeTyped::Typed(Cow::Owned(Numeric::from(r.start)))),
+                .map(|r| MaybeTyped::Typed(Cow::Owned(Numeric::from(*r.start())))),
             NumberVariable::PartNumber => self
                 .bound_select(
                     &select!(

--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -765,7 +765,7 @@ impl EntryLike for citationberg::json::Item {
             {
                 return n
                     .range()
-                    .map(|r| MaybeTyped::Typed(Cow::Owned(Numeric::from(r.start))));
+                    .map(|r| MaybeTyped::Typed(Cow::Owned(Numeric::from(*r.start()))));
             }
         }
         match self.0.get(&variable.to_string())? {

--- a/src/types/numeric.rs
+++ b/src/types/numeric.rs
@@ -218,7 +218,7 @@ impl Numeric {
     }
 
     /// Returns a range if the value is a range.
-    pub fn range(&self) -> Option<std::ops::Range<i32>> {
+    pub fn range(&self) -> Option<std::ops::RangeInclusive<i32>> {
         self.value.range()
     }
 
@@ -376,10 +376,10 @@ pub enum NumericValue {
 
 impl NumericValue {
     /// Returns a range if the value is a range.
-    pub fn range(&self) -> Option<std::ops::Range<i32>> {
+    pub fn range(&self) -> Option<std::ops::RangeInclusive<i32>> {
         match self {
             // A single number is seen as a range of length 1. See #103.
-            Self::Number(n) => Some(*n..*n),
+            Self::Number(n) => Some(*n..=*n),
             Self::Set(vec) => {
                 if vec.len() == 2 {
                     let start = vec[0].0;
@@ -391,10 +391,10 @@ impl NumericValue {
                             || (first_delim == Some(NumericDelimiter::Ampersand)
                                 && start + 1 == end))
                     {
-                        Some(start..end)
+                        Some(start..=end)
                     } else if first_delim == Some(NumericDelimiter::Hyphen) {
                         // Handle shorthand notation like `100-4` for `100-104`
-                        Some(start..end)
+                        Some(start..=end)
                     } else {
                         None
                     }
@@ -409,7 +409,7 @@ impl NumericValue {
                         }
                     }
 
-                    Some(vec[0].0..vec[vec.len() - 1].0)
+                    Some(vec[0].0..=vec[vec.len() - 1].0)
                 } else {
                     None
                 }

--- a/src/types/numeric.rs
+++ b/src/types/numeric.rs
@@ -379,7 +379,7 @@ impl NumericValue {
     pub fn range(&self) -> Option<std::ops::Range<i32>> {
         match self {
             // A single number is seen as a range of length 1. See #103.
-            Self::Number(n) => Some(*n..(*n + 1)),
+            Self::Number(n) => Some(*n..*n),
             Self::Set(vec) => {
                 if vec.len() == 2 {
                     let start = vec[0].0;

--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -17,6 +17,7 @@ bugreports_SingletonIfMatchNoneFail
 bugreports_TitleCase
 bugreports_YearSuffixLingers
 bugreports_disambiguate
+bugreports_effingBug
 bugreports_undefinedCrash
 collapse_AuthorCollapse
 collapse_AuthorCollapseDifferentAuthorsOneWithEtAl


### PR DESCRIPTION
Fix #142.

Page ranges are now `RangeInclusive<i32>`, which fits the semantics of a page range better. Also changes how single pages are turned to ranges: `4` now becomes the inclusive range `4..=4`, which fits.

Also, in citationberg, ranges where start and end are the same only render start.

Depends on typst/citationberg#12.

This is just a quick fix until I find time to rework page ranges.