### PR TITLE
fix: handle initials correctly

### DIFF
--- a/src/types/persons.rs
+++ b/src/types/persons.rs
@@ -257,7 +257,11 @@ impl Person {
                         }
 
                         collect = true;
-                        buf.write_char(if with_hyphen { c } else { ' ' })?;
+                        if with_hyphen && c == '-' {
+                            buf.write_char(c)?;
+                        } else if delimiter.is_some() {
+                            buf.write_char(' ')?;
+                        }
                     }
                     continue;
                 }
@@ -532,6 +536,11 @@ mod tests {
         let p = Person::from_strings(vec!["Dissmer", "Courtney Deliah"]).unwrap();
         p.initials(&mut s, Some("."), true).unwrap();
         assert_eq!("C. D.", s);
+
+        let mut s = String::new();
+        let p = Person::from_strings(vec!["Dissmer", "Courtney Deliah"]).unwrap();
+        p.initials(&mut s, None, true).unwrap();
+        assert_eq!("CD", s);
 
         let mut s = String::new();
         let p = Person::from_strings(vec!["Günther", "Hans-Joseph"]).unwrap();


### PR DESCRIPTION
This PR fixes the handling of initials when no delimiter is provided. Previously, citation styles that initialized without a delimiter (e.g., Vancouver) were formatted incorrectly. 

For example:
> **Doe J J.** World's Best Paper. Journal. 2025;99(9): 1–99.

instead of 
> **Doe JJ.** World's Best Paper. Journal. 2025;99(9): 1–99.

To fix this, we no longer add a space if no delimiter is passed.

Fixes #137.