### PR TITLE
Fix not using short titles

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -329,13 +329,13 @@ impl EntryLike for Entry {
                 .map(|f| f.select(form))
                 .map(Cow::Borrowed),
             StandardVariable::Status => None,
-            StandardVariable::Title => entry
+            StandardVariable::Title => {
+                entry.title().map(|f| f.select(form)).map(Cow::Borrowed)
+            }
+            StandardVariable::TitleShort => entry
                 .title()
                 .map(|f| f.select(LongShortForm::Short))
                 .map(Cow::Borrowed),
-            StandardVariable::TitleShort => {
-                entry.title().map(|f| f.select(form)).map(Cow::Borrowed)
-            }
             StandardVariable::URL => entry
                 .map(|e| e.url())
                 .map(|d| Cow::Owned(StringChunk::verbatim(d.to_string()).into())),

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -276,8 +276,14 @@ impl TryFrom<&tex::Entry> for Entry {
             item.add_affiliated_persons((a, PersonRole::Introduction));
         }
 
-        if let Some(title) = map_res(entry.title())?.map(Into::into) {
-            item.set_title(title);
+        if let Some(title) = map_res(entry.title())?.map(Into::<ChunkedString>::into) {
+            if let Some(short_title) =
+                map_res(entry.short_title())?.map(Into::<ChunkedString>::into)
+            {
+                item.set_title(FormatString::with_short(title, short_title));
+            } else {
+                item.set_title(FormatString::with_value(title));
+            }
         }
 
         // NOTE: Ignoring subtitle and titleaddon for now

--- a/src/types/strings.rs
+++ b/src/types/strings.rs
@@ -251,6 +251,12 @@ impl Serialize for ChunkedString {
     }
 }
 
+impl Into<String> for ChunkedString {
+    fn into(self) -> String {
+        return self.to_string();
+    }
+}
+
 impl ChunkedString {
     /// Creates a new empty `ChunkedString`.
     pub fn new() -> Self {


### PR DESCRIPTION
This PR is to address issue #173, which was that hayagriva did not use the BibTex `shorttitle` field for short titles in CSL. In order to fix this issue, I made two changes:

1. In [interop.rs](https://github.com/typst/hayagriva/compare/main...pjtsearch:fix-short-titles?expand=1#diff-f2d7ad31a3f6f942aa18f5b56f944448cdf5f10c83d0ea16e39caf36157247c7), I added functionality for detecting if the BibTex `shorttitle` exists and adding it to the `FormatString` if it does.
2. In [taxonomy.rs](https://github.com/typst/hayagriva/compare/main...pjtsearch:fix-short-titles?expand=1#diff-702ef24022db1313b47f2d64bc684ce2aee610ab03badbf79cf6cb50eb692559), I fixed the code for `StandardVariable::Title` and `StandardVariable::TitleShort` being switched around. Previously, hayagriva would always select the short title for `StandardVariable::Title`, but would choose between the short title and long title for `StandardVariable::TitleShort`, which is obviously incorrect behavior. It appears that the behavior for `StandardVariable::TitleShort` was mistakenly placed in `StandardVariable::Title`. I fixed this issue by simply switching the code around.