### PR TITLE
Fix affixes with layout tag

### DIFF
--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -1209,8 +1209,14 @@ impl RenderCsl for citationberg::LayoutRenderingElement {
 impl RenderCsl for citationberg::Layout {
     fn render<T: EntryLike>(&self, ctx: &mut Context<T>) {
         let fidx = ctx.push_format(self.to_formatting());
+        if let Some(ref prefix) = self.prefix {
+            ctx.push_str(prefix);
+        }
         for e in &self.elements {
             e.render(ctx);
+        }
+        if let Some(ref suffix) = self.suffix {
+            ctx.push_str(suffix);
         }
         ctx.pop_format(fidx);
     }


### PR DESCRIPTION
Fixes both prefixes and suffixes on the `<layout>` tag, which were not added before. I'm not sure if this is the correct way to implement this, I only took a cursory look through the code, but a quick test showed that it worked for the Chicago Manual of Style file.

Before:
```
Ungard-Sargon, Batya. “She Swoons to Conquer.” Edited by Pam Weintraub. Aeon (blog), September 25, 2015. https://aeon.co/essays/can-you-enjoy-romance-fiction-and-be-a-feminist
```
After:
```
Ungard-Sargon, Batya. “She Swoons to Conquer.” Edited by Pam Weintraub. Aeon (blog), September 25, 2015. https://aeon.co/essays/can-you-enjoy-romance-fiction-and-be-a-feminist.
```

Possibly addresses #107 