### PR TITLE
Add `abstract`, `annote`, and `genre` to documentation

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -193,7 +193,7 @@ This section lists all possible fields and data types for them.
 |------------------|-----------------------------------------------------------|
 | **Data type:**   | formattable string                                |
 | **Description:** | Short markup, decoration, or annotation to the item (e.g., to indicate items included in a review); For descriptive text (e.g., in an annotated bibliography), use `note` instead. |
-| **Example:**     | `annote:` |
+| **Example:**     | `annote: The researchers at NYU explore in this paper ...` |
 
 #### `genre`
 

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -192,7 +192,7 @@ This section lists all possible fields and data types for them.
 |                  |                                                           |
 |------------------|-----------------------------------------------------------|
 | **Data type:**   | formattable string                                |
-| **Description:** | Short markup, decoration, or annotation to the item (e.g., to indicate items included in a review); For descriptive text (e.g., in an annotated bibliography), use `note` instead. |
+| **Description:** | Short markup, decoration, or annotation to the item (e.g., to indicate items included in a review). For descriptive text (e.g., in an annotated bibliography), use `note` instead. |
 | **Example:**     | `annote: The researchers at NYU explore in this paper ...` |
 
 #### `genre`
@@ -200,7 +200,7 @@ This section lists all possible fields and data types for them.
 |                  |                                                           |
 |------------------|-----------------------------------------------------------|
 | **Data type:**   | formattable string                                |
-| **Description:** | Type, class, or subtype of the item (e.g. “Doctoral dissertation” for a PhD thesis; “NIH Publication” for an NIH technical report); Do not use for topical descriptions or categories (e.g. “adventure” for an adventure movie). |
+| **Description:** | Type, class, or subtype of the item (e.g. "Doctoral dissertation" for a PhD thesis; "NIH Publication" for an NIH technical report). Do not use for topical descriptions or categories (e.g. "adventure" for an adventure movie). |
 | **Example:**     | `genre: Doctoral dissertation` |
 
 #### `editor`

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -179,6 +179,30 @@ This section lists all possible fields and data types for them.
 | **Description:** | item in which the item was published / to which it is strongly associated to |
 | **Example:**     | <pre>parent:<br>    type: Anthology<br>    title: Automata studies<br>    editor: ["Shannon, C. E.", "McCarthy, J."]</pre> |
 
+#### `abstract`
+
+|                  |                                                           |
+|------------------|-----------------------------------------------------------|
+| **Data type:**   | formattable string                                |
+| **Description:** | Abstract of the item (e.g. the abstract of a journal article). |
+| **Example:**     | `abstract: The dominant sequence transduction models are based on complex...` |
+
+#### `annote`
+
+|                  |                                                           |
+|------------------|-----------------------------------------------------------|
+| **Data type:**   | formattable string                                |
+| **Description:** | Short markup, decoration, or annotation to the item (e.g., to indicate items included in a review); For descriptive text (e.g., in an annotated bibliography), use `note` instead. |
+| **Example:**     | `annote:` |
+
+#### `genre`
+
+|                  |                                                           |
+|------------------|-----------------------------------------------------------|
+| **Data type:**   | formattable string                                |
+| **Description:** | Type, class, or subtype of the item (e.g. “Doctoral dissertation” for a PhD thesis; “NIH Publication” for an NIH technical report); Do not use for topical descriptions or categories (e.g. “adventure” for an adventure movie). |
+| **Example:**     | `genre: Doctoral dissertation` |
+
 #### `editor`
 
 |                  |                                                           |
@@ -400,7 +424,6 @@ whole string in quotes if you do this.
 publisher: "{imagiNary} Publishing"
 ```
 
-
 To disable formatting altogether and instead preserve the casing as it appears
 in the source string, put the string in the `value` sub-field and specify
 another sub-field as `verbatim: true`:
@@ -479,7 +502,6 @@ names: ["Simon, David", "Colesberry, Robert F.", "Noble, Nina Kostroff"]
 - `director`. Directed the cited item.
 - `illustrator`. Illustrated the cited item.
 - `narrator`. Provided narration or voice-over for the cited item.
-
 
 The `role` field is case insensitive.
 


### PR DESCRIPTION
Documents the changes made in PR https://github.com/typst/hayagriva/pull/102.

@Drodt, could you contribute an example for `annote`? I am not familiar with this annotation and was hoping you could provide an example.