### PR TITLE
Fix CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ archive = ["ciborium"]
 csl-json = ["citationberg/json"]
 
 [dependencies]
-citationberg = { git = "https://github.com/typst/citationberg.git", rev = "858782e" }
+citationberg = { git = "https://github.com/typst/citationberg.git", rev = "61ca6a7fcc48365f805e521cc8bc1f8f679ff372" }
 indexmap = { version = "2.0.2", features = ["serde"] }
 numerals = "0.1.4"
 paste = "1.0.14"


### PR DESCRIPTION
Updates citationberg to a temporary `ci-fix` branch. To be corrected to citationberg's `main` once #155 is merged.