### PR TITLE
Ensure sorting items by standard variable is case-insensitive

### DIFF
--- a/src/csl/sort.rs
+++ b/src/csl/sort.rs
@@ -27,10 +27,10 @@ impl<'a> StyleContext<'a> {
             SortKey::Variable { variable: Variable::Standard(s), .. } => {
                 let a = InstanceContext::sort_instance(a, a_idx)
                     .resolve_standard_variable(LongShortForm::default(), *s)
-                    .map(|s| s.to_string());
+                    .map(|s| s.to_string().to_lowercase());
                 let b = InstanceContext::sort_instance(b, b_idx)
                     .resolve_standard_variable(LongShortForm::default(), *s)
-                    .map(|s| s.to_string());
+                    .map(|s| s.to_string().to_lowercase());
 
                 a.cmp(&b)
             }

--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -292,6 +292,7 @@ position_TrueInCitation
 punctuation_DateStripPeriods
 punctuation_DoNotSuppressColonAfterPeriod
 punctuation_NoSuppressOfPeriodBeforeSemicolon
+sort_CaseInsensitiveCitation
 sort_Citation
 sort_CitationSecondaryKey
 sort_CiteGroupDelimiter


### PR DESCRIPTION
Fixes sorting of citation items being case sensitive when using a standard variable (e.g. `title`) as the sort key.

Citeproc test `sort_CaseInsensitiveCitation`[^1] now passes.

[^1]: https://github.com/citation-style-language/test-suite/blob/4001cdada66cd30f2ba1b8ae45a8da20f407dec0/processor-tests/humans/sort_CaseInsensitiveCitation.txt