### PR TITLE
Make `page-range` `MabeType`d again

### DIFF
--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -431,10 +431,7 @@ impl RenderCsl for citationberg::Label {
                 };
 
                 let depth = ctx.push_elem(citationberg::Formatting::default());
-                let plural = match p {
-                    MaybeTyped::Typed(p) => p.is_plural(),
-                    _ => false,
-                };
+                let plural = p.as_typed().map_or(false, |p| p.is_plural());
 
                 let content =
                     ctx.term(Term::from(pv), self.label.form, plural).unwrap_or_default();
@@ -496,10 +493,7 @@ impl RenderCsl for citationberg::Label {
             }
             NumberOrPageVariable::Page(pv) => {
                 if let Some(p) = ctx.resolve_page_variable(pv) {
-                    let plural = match p {
-                        MaybeTyped::Typed(p) => p.is_plural(),
-                        _ => false,
-                    };
+                    let plural = p.as_typed().map_or(false, |p| p.is_plural());
                     (
                         ctx.term(Term::from(pv), self.label.form, plural).is_some(),
                         UsageInfo::default(),

--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -173,6 +173,7 @@ impl EntryLike for Entry {
             }
             NumberVariable::PageFirst => self
                 .page_range()
+                .and_then(MaybeTyped::as_typed)
                 .and_then(PageRanges::first)
                 .map(|r| MaybeTyped::Typed(Cow::Owned(r.clone()))),
             NumberVariable::PartNumber => self
@@ -216,7 +217,7 @@ impl EntryLike for Entry {
         variable: PageVariable,
     ) -> Option<MaybeTyped<PageRanges>> {
         match variable {
-            PageVariable::Page => self.page_range().map(|r| MaybeTyped::Typed(r.clone())),
+            PageVariable::Page => self.page_range().cloned(),
         }
     }
 

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,7 +1,6 @@
 //! Provides conversion methods for BibLaTeX.
 
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 use biblatex as tex;
 use tex::{
@@ -491,7 +490,7 @@ impl TryFrom<&tex::Entry> for Entry {
 
         if let Some(pages) = map_res(entry.pages())? {
             item.set_page_range(match pages {
-                PermissiveType::Typed(pages) => PageRanges::new(
+                PermissiveType::Typed(pages) => MaybeTyped::Typed(PageRanges::new(
                     pages
                         .into_iter()
                         .map(|p| {
@@ -505,9 +504,9 @@ impl TryFrom<&tex::Entry> for Entry {
                             }
                         })
                         .collect(),
-                ),
+                )),
                 PermissiveType::Chunks(chunks) => {
-                    PageRanges::from_str(&chunks.format_verbatim()).unwrap()
+                    MaybeTyped::infallible_from_str(&chunks.format_verbatim())
                 }
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,7 +522,7 @@ entry! {
     /// Published version of an item.
     "edition" => edition: MaybeTyped<Numeric>,
     /// The range of pages within the parent this item occupies
-    "page-range" => page_range: PageRanges,
+    "page-range" => page_range: MaybeTyped<PageRanges>,
     /// The total number of pages the item has.
     "page-total" => page_total: Numeric,
     /// The time range within the parent this item starts and ends at.
@@ -981,5 +981,24 @@ mod tests {
             entries >> "wwdc-network",
             ["a", "b", "c"]
         );
+    }
+
+    #[test]
+    #[cfg(feature = "biblatex")]
+    fn test_troublesome_page_ranges() {
+        use io::from_biblatex_str;
+
+        let bibtex = r#"
+            @article{b, 
+                title={My page ranges},
+                pages={150--es}
+            }
+        "#;
+
+        let library = from_biblatex_str(bibtex).unwrap();
+
+        for entry in library.iter() {
+            assert!(entry.page_range.is_some())
+        }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -304,6 +304,16 @@ pub enum MaybeTyped<T> {
     String(String),
 }
 
+impl<T> MaybeTyped<T> {
+    /// Get the typed value, if it is present.
+    pub fn as_typed(&self) -> Option<&T> {
+        match self {
+            MaybeTyped::Typed(t) => Some(t),
+            MaybeTyped::String(_) => None,
+        }
+    }
+}
+
 impl<T: ToOwned> MaybeTyped<T> {
     /// Wrap the typed value in a [`Cow`]'s borrowed variant.
     pub fn to_cow(&self) -> MaybeTyped<Cow<T>> {


### PR DESCRIPTION
#155 introduced a problem where BibLaTeX files with invalid page ranges such as `150--es` would crash the compiler. This PR makes them `MaybeType`d again. I ran [the file that originally showed us the crash](https://github.com/Dherse/masterproef/blob/9851952f04632a739540b36e85b26e60ba2bc298/masterproef/assets/references.bib) through the BibLaTeX parsing with success.