### PR TITLE
Fix #227

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -46,7 +46,7 @@ macro_rules! deserialize_from_str {
                 D: serde::Deserializer<'de>,
             {
                 let s = <&'de str>::deserialize(deserializer)?;
-                FromStr::from_str(s).map_err(de::Error::custom)
+                FromStr::from_str(s).map_err(serde::de::Error::custom)
             }
         }
     };
@@ -74,18 +74,38 @@ macro_rules! derive_or_from_str {
             )*
         }
 
+        derive_or_from_str!(@deser_impl $s where $expect,
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+                where A: serde::de::MapAccess<'de>, {
+                use serde::{de, Deserialize};
 
-        impl<'de> Deserialize<'de> for $s {
+                #[derive(Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                struct Inner {
+                    $(
+                        $(#[serde $serde])*
+                        $i: $t,
+                    )*
+                }
+
+                Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+                    .map(|inner: Inner| $s { $($i: inner.$i),* })
+            }
+        );
+    };
+
+    (@deser_impl $type_name:ident where $expect:literal, $visit_map:item $(, $additional_visitors:item)*) => {
+        impl<'de> Deserialize<'de> for $type_name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
             D: serde::Deserializer<'de>,
             {
                 use std::fmt;
-                use serde::de::{self, Visitor};
+                use serde::de::{Visitor};
                 struct OurVisitor;
 
                 impl<'de> Visitor<'de> for OurVisitor {
-                    type Value = $s;
+                    type Value = $type_name;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                         formatter.write_str($expect)
@@ -98,22 +118,9 @@ macro_rules! derive_or_from_str {
                         Self::Value::from_str(value).map_err(|e| E::custom(e.to_string()))
                     }
 
-                    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
-                    where
-                        A: serde::de::MapAccess<'de>,
-                    {
-                        #[derive(Deserialize)]
-                        #[serde(rename_all = "kebab-case")]
-                        struct Inner {
-                            $(
-                                $(#[serde $serde])*
-                                $i: $t,
-                            )*
-                        }
+                    $visit_map
 
-                        Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
-                            .map(|inner: Inner| $s { $($i: inner.$i),* })
-                    }
+                    $($additional_visitors)*
                 }
 
                 deserializer.deserialize_any(OurVisitor)
@@ -594,5 +601,28 @@ mod tests {
 
         assert!(Numeric::from_str("second").is_err());
         assert!(Numeric::from_str("2nd edition").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "biblatex")]
+    fn test_issue_227() {
+        let yaml = r#"
+AAAnonymous_AventureMortevielle_1987:
+  type: Book
+  page-range: 100"#;
+
+        let library = crate::io::from_yaml_str(yaml).unwrap();
+        let entry = library.get("AAAnonymous_AventureMortevielle_1987").unwrap();
+        assert_eq!(
+            entry
+                .page_range
+                .as_ref()
+                .unwrap()
+                .as_typed()
+                .unwrap()
+                .first()
+                .unwrap(),
+            &Numeric::new(100)
+        );
     }
 }

--- a/src/types/numeric.rs
+++ b/src/types/numeric.rs
@@ -46,7 +46,9 @@ impl<'de> Deserialize<'de> for Numeric {
 
             /// A default serde fallthrough handler for signed integers.
             fn visit_i64<E: Error>(self, v: i64) -> Result<Self::Value, E> {
-                Ok(Numeric::new(v.try_into().map_err(|_| E::custom("value too large"))?))
+                Ok(Numeric::new(
+                    v.try_into().map_err(|_| E::custom("value out of bounds"))?,
+                ))
             }
 
             fn visit_i32<E: Error>(self, v: i32) -> Result<Self::Value, E> {


### PR DESCRIPTION
With the new page range type, `Deserialize` only returned `Ok` if the value was a string. This PR adds conversions for i32, u32, and u64 values which YAML can easily yield for single pages

Fixes #227