### PR TITLE
Fix yaml syntax problem in file-format.md

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -154,7 +154,7 @@ This section lists all possible fields and data types for them.
 |------------------|-----------------------------------------------------------|
 | **Data type:**   | formattable string                                        |
 | **Description:** | title of the item                                         |
-| **Example:**     | `title: Rick Astley: How An Internet Joke Revived My Career` |
+| **Example:**     | `title: "Rick Astley: How An Internet Joke Revived My Career"` |
 
 #### `author`
 


### PR DESCRIPTION
The `title` example was seemingly invalid YAML. Adding quotes fixes this