### PR TITLE
Fix crash on multibyte char in page ranges #241

### DIFF
--- a/src/types/page.rs
+++ b/src/types/page.rs
@@ -367,11 +367,8 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.string.is_empty() {
-            None
-        } else {
-            let mut len =
-                self.string.chars().next().map(char::len_utf8).unwrap_or_default();
+        if let Some(first_char) = self.string.chars().next() {
+            let mut len = first_char.len_utf8();
             for (c, d) in self.string.chars().zip(self.string.chars().skip(1)) {
                 if (self.predicate)(c, d) {
                     len += d.len_utf8();
@@ -382,6 +379,8 @@ where
             let (head, tail) = self.string.split_at(len);
             self.string = tail;
             Some(head)
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
This fixes #241, which is a bug caused by incorrectly splitting the page ranges into groups.
The index calculation fails to account for a multibyte character at the end of a pages group. The subsequent split operation on the incorrect index leads to a crash, as described in the issue.

Examples:
```bib
@article{foo,
  ...
  pages     = {321--},
  ...
}
@article{bar,
  ...
  pages     = {321–},
  ...
}
```
Both page ranges are converted to a `321` followed by `–`, which is an utf8 character with multiple bytes

In addition to the fix, I've added a few tests for this and removed the string window in favor of the chars iterator from the std.