### PR TITLE
Apostrophe should not always cause step to return CharClass::InWord

### DIFF
--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -164,7 +164,7 @@ impl CharClass {
             }
             '(' | '[' | '{' => Self::NewSubclause,
             ')' | ']' | '}' => self,
-            '"' | '”' | '“' | '»' | '›' | '«' | '‹' | '‘' => self,
+            '"' | '”' | '“' | '»' | '›' | '«' | '‹' | '‘' | '\'' => self,
             ',' | ';' => {
                 if self.is_in_word() {
                     Self::MaybeSubclause
@@ -913,6 +913,10 @@ mod tests {
         let title =
             case.transform("Around a table: the reason why we just could not care");
         assert_eq!("Around a Table: The Reason Why We Just Could Not Care", title);
+
+        let title =
+        case.transform("'My colleague is a robot' – exploring frontline employees' willingness to work with collaborative service robots");
+        assert_eq!("'My Colleague Is a Robot' – Exploring Frontline Employees' Willingness to Work with Collaborative Service Robots", title);
     }
 
     #[test]


### PR DESCRIPTION
Similar to `"`, `”`, `«`, and other such characters, an apostrophe can mark a quotation, in which case the character after it may need to be upper case. Before this commit, Hayagriva always considered the character after an apostrophe to be within a word, and therefore lowercased it.

Closes #196