### PR TITLE
Fix --format CLI flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use std::fs::{self, read_to_string};
 use std::io::ErrorKind as IoErrorKind;
 use std::path::Path;
 use std::process::exit;
-use std::str::FromStr;
 
 use citationberg::taxonomy::Locator;
 use citationberg::{
@@ -28,21 +27,6 @@ pub enum Format {
     #[cfg(feature = "biblatex")]
     Biblatex,
     Yaml,
-}
-
-impl FromStr for Format {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, &'static str> {
-        match s.to_ascii_lowercase().as_ref() {
-            #[cfg(feature = "biblatex")]
-            "bibtex" => Ok(Format::Bibtex),
-            #[cfg(feature = "biblatex")]
-            "biblatex" => Ok(Format::Biblatex),
-            "yaml" => Ok(Format::Yaml),
-            _ => Err("unknown format"),
-        }
-    }
 }
 
 impl ValueEnum for Format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ use citationberg::taxonomy::Locator;
 use citationberg::{
     IndependentStyle, Locale, LocaleCode, LocaleFile, LongShortForm, Style,
 };
-use clap::{crate_version, Arg, ArgAction, Command};
+use clap::builder::PossibleValue;
+use clap::{crate_version, Arg, ArgAction, Command, ValueEnum};
 use strum::VariantNames;
 
 use hayagriva::archive::{locales, ArchivedStyle};
@@ -44,6 +45,28 @@ impl FromStr for Format {
     }
 }
 
+impl ValueEnum for Format {
+    fn value_variants<'a>() -> &'a [Self] {
+        if cfg!(feature = "biblatex") {
+            &[Self::Bibtex, Self::Biblatex, Self::Yaml]
+        } else {
+            &[Self::Yaml]
+        }
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        let value = match self {
+            #[cfg(feature = "biblatex")]
+            Format::Bibtex => "bibtex",
+            #[cfg(feature = "biblatex")]
+            Format::Biblatex => "biblatex",
+            Format::Yaml => "yaml",
+        };
+
+        Some(PossibleValue::new(value))
+    }
+}
+
 /// Main function of the Hayagriva CLI.
 fn main() {
     let matches = Command::new("Hayagriva CLI")
@@ -59,7 +82,7 @@ fn main() {
                 Arg::new("format")
                     .long("format")
                     .help("What input file format to expect")
-                    .value_parser(clap::builder::PossibleValuesParser::new(Format::VARIANTS))
+                    .value_parser(clap::value_parser!(Format))
                     .ignore_case(true)
                     .num_args(1)
                     .global(true),


### PR DESCRIPTION
Previously, the CLI used clap's PossibleValueParser, which only supports parsing strings. However, hayagriva was expecting to parse Format directly. This caused a panic in clap, when trying to convert the String to Format.

With this patch, Format implements ValueEnum, so we can use clap::value_parser to create an EnumValueParser to parse the Format.