### PR TITLE
Fix handling of trailing whitespaces in initials' delimiters

### DIFF
--- a/src/types/persons.rs
+++ b/src/types/persons.rs
@@ -327,7 +327,7 @@ impl Person {
         Ok(())
     }
 
-    /// Get the name with the family name fist, the initials
+    /// Get the name with the family name first, the initials
     /// afterwards, separated by a comma.
     pub fn name_first(&self, initials: bool, prefix_given_name: bool) -> String {
         let mut res = if !prefix_given_name {
@@ -613,5 +613,17 @@ mod tests {
         let mut s = String::new();
         p.first_name_with_delimiter(&mut s, Some(".")).unwrap();
         assert_eq!("James T.", s);
+    }
+
+    #[test]
+    fn person_name_retrieval_order() {
+        let p =
+            Person::from_strings(vec!["van Dissmer", "Jr.", "Courtney Deliah"]).unwrap();
+        assert_eq!("van Dissmer, Courtney Deliah, Jr.", p.name_first(false, false));
+        assert_eq!("Dissmer, Courtney Deliah van, Jr.", p.name_first(false, true));
+        assert_eq!("van Dissmer, C. D., Jr.", p.name_first(true, false));
+        assert_eq!("Dissmer, C. D. van, Jr.", p.name_first(true, true));
+        assert_eq!("Courtney Deliah van Dissmer Jr.", p.given_first(false));
+        assert_eq!("C. D. van Dissmer Jr.", p.given_first(true));
     }
 }

--- a/src/types/persons.rs
+++ b/src/types/persons.rs
@@ -577,6 +577,11 @@ mod tests {
 
         let mut s = String::new();
         let p = Person::from_strings(vec!["Günther", "Hans-Joseph"]).unwrap();
+        p.initials(&mut s, Some(""), true).unwrap();
+        assert_eq!("H-J", s);
+
+        let mut s = String::new();
+        let p = Person::from_strings(vec!["Günther", "Hans-Joseph"]).unwrap();
         p.initials(&mut s, None, true).unwrap();
         assert_eq!("H-J", s);
 

--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -188,6 +188,7 @@ name_AsianGlyphs
 name_AuthorCountWithSameVarContentAndCombinedTermFail
 name_AuthorCountWithSameVarContentAndCombinedTermSucceed
 name_CelticClanName
+name_CeltsAndToffsNoHyphens
 name_CeltsAndToffsWithHyphens
 name_CiteGroupDelimiterWithYearCollapse
 name_CollapseRoleLabels
@@ -206,6 +207,7 @@ name_InstitutionDecoration
 name_LabelAfterPlural
 name_LabelAfterPluralDecorations
 name_LabelFormatBug
+name_MultipleLiteral
 name_NoNameNode
 name_NonDroppingParticleDefault
 name_OnlyFamilyname


### PR DESCRIPTION
Fixes #137

Some styles, such as `vancouver`, require there to be nothing between initials, so `Astley, Rick Gavin` would be formatted as `Astley, RG` instead of `Astley, R. G.` (more usual) or `Astley, R G` for example. However, even when setting `initializer-with=""` (empty delimiter), Hayagriva was still forcing whitespaces between initials.

It was thought that #150 would have fixed it by only adding whitespaces if a delimiter was indeed specified, but it actually didn't change anything as **there is always a delimiter** - however, it is sometimes **an empty string**. While adding an explicit check for empty strings would have fixed this specific problem, it turns out Hayagriva's behavior of forcing a whitespace to always be added after the delimiter, replacing any of its trailing whitespaces if there are any (otherwise, one is added anyways), is not consistent with other CSL processors. Indeed, several citeproc tests demonstrated that the expected way to add whitespaces between initials is through `initializer-with=". "` instead of `initializer-with="."`. So, I removed Hayagriva's automatic whitespace behavior, **except** when we're replacing hyphens (e.g. for `initializer-with=". "`, `Aa-Bb` should become `A.-B.` and not `A. -B.`).

It is, however, unfortunate that this seems to be somewhat inconsistent with a specific example given by the relevant section of the CSL 1.0.2 spec:

```md
`initialize-with`
    When set, given names are converted to initials. The attribute value is added after each initial (“.” results in “J. J. Doe”).
```

...but most official styles I've seen appear to assume that whitespaces are preserved, using `". "` instead of `"."` in that case. So this seems to be the way to go.

I've also added some tests. Two more citeproc tests are now passing as well.

I'll be keeping this as a draft as I still need to test the case with `initialize="false", initialize-with="."`, but in principle the code seems to preserve whitespace here as well, however whitespaces from the name itself are also kept, which is why `initialize-with="."` is used instead of `initialize-with=". "` by official styles in this case.