### PR TITLE
Add translation for pubmed eprint

### DIFF
--- a/src/interop.rs
+++ b/src/interop.rs
@@ -583,3 +583,25 @@ fn comma_list(items: &[Vec<Spanned<Chunk>>]) -> FormatString {
 
     FormatString { value, short: None }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_pmid_from_biblatex() {
+        let entries = crate::io::from_biblatex_str(r#"@article{test_article,
+	title = {Title},
+	volume = {3},
+	url = {https://example.org},
+	pages = {1--99},
+	journaltitle = {Testing Journal},
+	author = {Doe, Jane},
+	date = {2024-12},
+ eprint = {54678},
+ eprinttype = {pubmed},
+}"#).unwrap();
+        let entry = entries.get("test_article").unwrap();
+        assert_eq!(Some("54678"), entry.keyed_serial_number("pmid"));
+        assert_eq!(Some("54678"), entry.pmid());
+    }
+}
+

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -588,7 +588,8 @@ fn comma_list(items: &[Vec<Spanned<Chunk>>]) -> FormatString {
 mod tests {
     #[test]
     fn test_pmid_from_biblatex() {
-        let entries = crate::io::from_biblatex_str(r#"@article{test_article,
+        let entries = crate::io::from_biblatex_str(
+            r#"@article{test_article,
 	title = {Title},
 	volume = {3},
 	url = {https://example.org},
@@ -598,10 +599,11 @@ mod tests {
 	date = {2024-12},
  eprint = {54678},
  eprinttype = {pubmed},
-}"#).unwrap();
+}"#,
+        )
+        .unwrap();
         let entry = entries.get("test_article").unwrap();
         assert_eq!(Some("54678"), entry.keyed_serial_number("pmid"));
         assert_eq!(Some("54678"), entry.pmid());
     }
 }
-

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -421,7 +421,7 @@ impl TryFrom<&tex::Entry> for Entry {
             if eprint_type == Some("arxiv") {
                 item.set_arxiv(eprint);
             } else if eprint_type == Some("pubmed") {
-                item.set_pmid(eprint.replace("http://www.ncbi.nlm.nih.gov/pubmed/", ""));
+                item.set_pmid(eprint);
             }
         }
 


### PR DESCRIPTION
As in §3.14.7 of the [biblatex documentation](https://ftp.mpi-inf.mpg.de/pub/tex/mirror/ftp.dante.de/pub/tex/macros/latex/contrib/biblatex/doc/biblatex.pdf).

Addresses #260.