### PR TITLE
refactor(errors)!: added proper error handling

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,44 @@
+/// A nice wrapper for handling errors in the `main()`.
+/// Must be called from `main()`.
+#[macro_export]
+macro_rules! err {
+    (@private, $result:expr, $format_string:literal, $exit_code:expr) => {
+        match $result {
+            Ok(v) => v,
+            Err(err) => {
+                eprintln!($format_string, err);
+                return $exit_code;
+            }
+        }
+    };
+    ($result:expr, $exit_code:expr) => {
+        err!(@private, $result, "{}", ExitCode::from($exit_code))
+    };
+    ($result:expr) => {
+        err!(@private, $result, "{}", ExitCode::FAILURE)
+    };
+}
+
+/// Like `err!()`, but requires a format string with `"{}"`.
+/// Must be called from `main()`.
+#[macro_export]
+macro_rules! err_fmt {
+    ($result:expr, $format_string:literal, $exit_code:literal) => {
+        err!(@private, $result, $format_string, ExitCode::from($exit_code))
+    };
+    ($result:expr, $format_string:literal) => {
+        err!(@private, $result, $format_string, ExitCode::FAILURE)
+    };
+}
+
+/// Like `err!()`, but you can directly specify the error message with `&str`/`String`.
+/// Must be called from `main()`.
+#[macro_export]
+macro_rules! err_str {
+    ($error_string:expr, $exit_code:expr) => {
+        err!(Err(Error::OtherError($error_string.into())), $exit_code)
+    };
+    ($error_string:expr) => {
+        err_str!($error_string, ExitCode::FAILURE)
+    };
+}

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+
+#[cfg(feature = "biblatex")]
+pub use biblatex_module::*;
+
+/// The main error that is handled in the `main()` function.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Bibliography error.
+    #[error("Bibliography error: {0}")]
+    BibliographyError(#[from] BibliographyError),
+    /// Invalid Bib(La)TeX input file format.
+    #[cfg(feature = "biblatex")]
+    #[error("Invalid format: expected Bib(La)TeX\nCaused by:\n\t{0:?}")]
+    InvalidBiblatex(#[from] BibLaTeXErrors),
+    /// Invalid YAML input file format.
+    #[error("Invalid format: expected YAML\nCaused by:\n\t{0:?}")]
+    InvalidYaml(#[from] serde_yaml::Error),
+    /// Other error.
+    #[error("{0}")]
+    OtherError(String),
+}
+
+/// The error when reading bibliography file.
+#[derive(thiserror::Error, Debug)]
+pub enum BibliographyError {
+    /// Bibliography file not found.
+    #[error("Bibliography file {0:?} not found.")]
+    NotFound(PathBuf),
+    /// Error while reading the bibliography file (with OS error code).
+    #[error("Error while reading the bibliography file {0:?}: {1}")]
+    ReadErrorWithCode(PathBuf, i32),
+    /// Error while reading the bibliography file.
+    #[error("Error while reading the bibliography file {0:?}.")]
+    ReadError(PathBuf),
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        Self::OtherError(value.into())
+    }
+}
+
+#[cfg(feature = "biblatex")]
+mod biblatex_module {
+    use std::{error::Error, fmt::Display};
+
+    /// Errors that may occur when parsing a BibLaTeX file.
+    #[derive(thiserror::Error, Clone, Debug)]
+    pub enum BibLaTeXError {
+        /// An error occurred when parsing a BibLaTeX file.
+        Parse(biblatex::ParseError),
+        /// One of the BibLaTeX fields was malformed for its type.
+        Type(biblatex::TypeError),
+    }
+
+    impl Display for BibLaTeXError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Parse(err) => write!(f, "biblatex parse error: {}", err),
+                Self::Type(err) => write!(f, "biblatex type error: {}", err),
+            }
+        }
+    }
+
+    /// Wrapper over an array of `BibLaTeXError` elements.
+    #[derive(thiserror::Error, Clone, Debug)]
+    pub struct BibLaTeXErrors(pub Vec<BibLaTeXError>);
+
+    impl Display for BibLaTeXErrors {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let sources = self
+                .0
+                .clone()
+                .into_iter()
+                .filter_map(|x| x.source().map(|err| format!("{err:?}")))
+                .collect::<Vec<String>>()
+                .join("\n\t");
+            write!(f, "{sources}")
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,6 +17,8 @@ pub use persons::*;
 pub use strings::*;
 pub use time::*;
 
+/// Provides error types.
+pub mod error;
 mod numeric;
 mod page;
 mod persons;


### PR DESCRIPTION
[Today I discovered a new issue with Typst + Hayagriva + CSL](https://discord.com/channels/1054443721975922748/1088371867913572452/1318432199703400459). I thought of installing the Hayagriva CLI to test what's wrong, but then I was confused by the order and requiredness of the CLI arguments. But then eventually I hit a panic with:

```sh
hayagriva bib.yaml reference --select . --csl bib-style.csl
```

And with backtrace I only was able to find that this is the problem:

https://github.com/typst/hayagriva/blob/38a56c8dea69531befea140aa51ca913fe9ca586/src/main.rs#L242-L252

To cut the story short, the problem was with coercing the CLI argument to `&str` because of `Selector::parse()` which also panicked with `try_get_one`. So the solution is to get `String` instead. Solved. Thought I would make a quick PR. But then I also tried this:

```sh
hayagriva bib.yaml reference --csl ieee
hayagriva bib.yaml reference --style ieee --format biblatex
```

And they both produced different panic errors. And indeed, throughout the `main.rs` (and not only there) there are a ton of `.expect()`. This was shocking to me, especially compared to Typst. So one thing lead to another and here we are.

I asked the rustaceans a few pointers on various things and this is the more or less final result. My main concern is the return type of public functions in `io` module. For super easy error handling in `main()` I had to convert to the final error right away (also one of the advices from the community). Which can go both ways: either we don't touch the public API and revert some changes, or we embrace the breakage and perhaps look into other places where this unified error can be used. And maybe more `panic`s can be removed in the codebase.

The good thing is that I didn't use any new dependencies. There are 2 best ways to handle errors in the main (in the CLI):
- moving everything to `run()` and printing all the errors once in the `main()` where the `run()` is called;
- using `main() -> ExitCode` and returning either `SUCCESS`/`FAILURE` or using `from(u8)` which I didn't know of before.

`main() -> Return<(), ExitCode>` isn't great, because not only you have to map `Debug` impl to `Display` impl for `thiserror`'s error messages to work, but also on `?` in `main()` you always will get `Error: ` at the end of any error message.

I think the code can significantly simplified even further if the secondary `main()` function is used (`run()`). For now I created a few helpful macros to easily return the necessary exit code from the main.
BTW, I haven't found any table with "error code → error type" mappings in the docs. So different exit codes now look random, but I kept them.

I think that other than `run()` and deciding on the "public API return type change" there isn't anything else I think should be done.
