### PR TITLE
Hayagriva JSON Schema (using specification Draft-07)

### DIFF
--- a/hayagriva.schema.json
+++ b/hayagriva.schema.json
@@ -1,0 +1,471 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Hayagriva Bibliography Format",
+  "type": "object",
+  "description": "A bibliography management format for the modern age.",
+  "additionalProperties": {
+    "$ref": "#/definitions/entry"
+  },
+  "definitions": {
+    "entry": {
+      "type": "object",
+      "description": "A single bibliography entry.",
+      "examples": [
+        {
+          "harry": {
+            "type": "Book",
+            "title": "Harry Potter and the Order of the Phoenix",
+            "author": "Rowling, J. K.",
+            "volume": 5,
+            "page-total": 768,
+            "date": "2003-06-21T00:00:00.000Z"
+          }
+        },
+        {
+          "electronic": {
+            "type": "Web",
+            "title": "Ishkur's Guide to Electronic Music",
+            "serial-number": "v2.5",
+            "author": "Ishkur",
+            "url": "http://www.techno.org/electronic-music-guide/"
+          }
+        }
+      ],
+      "properties": {
+        "type": { "$ref": "#/definitions/entryType" },
+        "title": {
+          "description": "The title of this entry",
+          "examples": ["Rick Astley: How An Internet Joke Revived My Career"],
+          "$ref": "#/definitions/formattableString"
+        },
+        "author": {
+          "description": "People primarily responsible for the creation of this entry",
+          "examples": [["Klocke, Iny", "Wohlrath, Elmar"]],
+          "oneOf": [
+            {
+              "$ref": "#/definitions/person"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/person"
+              }
+            }
+          ]
+        },
+        "date": {
+          "description": "The date of publication or creation of this entry",
+          "$ref": "#/definitions/date"
+        },
+        "parent": {
+          "description": "Entry in which the current entry was published / to which it is strongly associated to",
+          "examples": [
+            {
+              "type": "Anthology",
+              "title": "Automata studies",
+              "editor": ["Shannon, Claude E.", "McCarthy, John"]
+            }
+          ],
+          "$ref": "#/definitions/parentOrArray"
+        },
+        "abstract": {
+          "$ref": "#/definitions/formattableString",
+          "description": "Abstract of the entry",
+          "examples": [
+            "The dominant sequence transduction models are based on complex..."
+          ]
+        },
+        "genre": {
+          "description": "Type, class, or subtype of the item (e.g. \"Doctoral dissertation\" for a PhD thesis; \"NIH Publication\" for an NIH technical report). Do not use for topical descriptions or categories (e.g. \"adventure\" for an adventure movie)",
+          "$ref": "#/definitions/formattableString",
+          "examples": ["Doctoral dissertation"]
+        },
+        "editor": {
+          "description": "People responsible for selecting and revising the content of the entry",
+          "examples": ["Stringer, Gary A.", "Pebworth, Ted-Larry"],
+          "$ref": "#/definitions/personOrList"
+        },
+        "affiliated": {
+          "description": "People involved with the entry that do not fit author or editor roles",
+          "examples": [
+            {
+              "role": "Director",
+              "names": "Cameron, James"
+            },
+            {
+              "role": "CastMember",
+              "names": [
+                "Schwarzenegger, Arnold",
+                "Hamilton, Linda",
+                "Patrick, Robert"
+              ]
+            }
+          ],
+          "$ref": "#/definitions/affiliatedList"
+        },
+        "call-number": {
+          "$ref": "#/definitions/formattableString",
+          "description": "The number of the item in a library, institution, or collection. Use with archive",
+          "examples": ["F16 D14"]
+        },
+        "publisher": {
+          "description": "The name of the publisher",
+          "examples": [
+            "Penguin Books",
+            {
+              "name": "Penguin Books",
+              "location": "London"
+            }
+          ],
+          "$ref": "#/definitions/publisher"
+        },
+        "location": {
+          "$ref": "#/definitions/formattableString",
+          "description": "Location at which the entry is physically located or took place. For the location where an item was published, use publisher instead.",
+          "examples": ["Lahore, Pakistan"]
+        },
+        "organization": {
+          "description": "Organization at/for which the entry was produced",
+          "examples": ["Technische Universität Berlin"],
+          "$ref": "#/definitions/formattableString"
+        },
+        "issue": {
+          "$ref": "#/definitions/numericOrString",
+          "description": "For an entry whose parent has multiple issues, indicated the position in the issue sequence. Also used to indicate the episode number for TV",
+          "examples": [5]
+        },
+        "volume": {
+          "$ref": "#/definitions/numericOrString",
+          "description": "For an entry whose parent has multiple volumes, parts, seasons, etc. of which this entry is one",
+          "examples": ["2-3"]
+        },
+        "volume-total": {
+          "type": "integer",
+          "examples": [12],
+          "description": "Total number of volumes, parts, seasons, etc. this entry is part of"
+        },
+        "edition": {
+          "$ref": "#/definitions/numericOrString",
+          "description": "Published version of the entry",
+          "examples": ["expanded and revised edition"]
+        },
+        "page-range": {
+          "$ref": "#/definitions/numericOrString",
+          "description": "Range of pages within the parent this entry occupies",
+          "examples": ["812-847"]
+        },
+        "page-total": {
+          "type": "integer",
+          "description": "Total number of pages in the entry",
+          "examples": [768]
+        },
+        "time-range": {
+          "description": "The time range within the parent this entry starts and ends at",
+          "examples": ["00:57-06:21"],
+          "$ref": "#/definitions/timestampRange"
+        },
+        "runtime": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "url": {
+          "$ref": "#/definitions/url"
+        },
+        "serial-number": {
+          "$ref": "#/definitions/serialNumber"
+        },
+        "language": {
+          "$ref": "#/definitions/language"
+        },
+        "archive": {
+          "$ref": "#/definitions/formattableString"
+        },
+        "archive-location": {
+          "$ref": "#/definitions/formattableString"
+        },
+        "note": {
+          "$ref": "#/definitions/formattableString"
+        }
+      },
+      "additionalProperties": false
+    },
+    "publisher": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "entryType": {
+      "type": "string",
+      "examples": [
+        "article",
+        "chapter",
+        "entry",
+        "anthos",
+        "report",
+        "thesis",
+        "web",
+        "scene",
+        "artwork",
+        "patent",
+        "case",
+        "newspaper",
+        "legislation",
+        "manuscript",
+        "original",
+        "post",
+        "misc",
+        "performance",
+        "periodical",
+        "proceedings",
+        "book",
+        "blog",
+        "reference",
+        "conference",
+        "anthology",
+        "repository",
+        "thread",
+        "video",
+        "audio",
+        "exhibition"
+      ],
+      "description": "Media type of the item, often determines the structure of references.",
+      "pattern": "^(?i)(article|chapter|entry|anthos|report|thesis|web|scene|artwork|patent|case|newspaper|legislation|manuscript|original|post|misc|performance|periodical|proceedings|book|blog|reference|conference|anthology|repository|thread|video|audio|exhibition)$"
+    },
+    "parentOrArray": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/entry"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/entry"
+          }
+        }
+      ]
+    },
+    "affiliatedList": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "$ref": "#/definitions/roleType"
+          },
+          "names": {
+            "$ref": "#/definitions/personOrList"
+          }
+        },
+        "required": ["role", "names"],
+        "additionalProperties": false
+      }
+    },
+    "roleType": {
+      "type": "string",
+      "examples": [
+        "translator",
+        "afterword",
+        "foreword",
+        "introduction",
+        "annotator",
+        "commentator",
+        "holder",
+        "compiler",
+        "founder",
+        "collaborator",
+        "organizer",
+        "cast-member",
+        "composer",
+        "producer",
+        "executive-producer",
+        "writer",
+        "cinematography",
+        "director",
+        "illustrator",
+        "narrator"
+      ],
+      "pattern": "^(?i)(translator|afterword|foreword|introduction|annotator|commentator|holder|compiler|founder|collaborator|organizer|cast-member|composer|producer|executive-producer|writer|cinematography|director|illustrator|narrator)$"
+    },
+    "formattableString": {
+      "description": "A formattable string is a string that may run through a text case transformer when used in a reference or citation. You can disable these transformations on segments of the string or the whole string.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            },
+            "verbatim": {
+              "description": "",
+              "type": "boolean"
+            },
+            "short": {
+              "type": "string"
+            }
+          },
+          "required": ["value"]
+        }
+      ]
+    },
+    "person": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "given-name": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string"
+            },
+            "suffix": {
+              "type": "string"
+            },
+            "alias": {
+              "type": "string"
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "personOrList": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/person"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/person"
+          }
+        }
+      ]
+    },
+    "date": {
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "date",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "$comment": "YYYY-MM-DD format"
+        },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "$comment": "Year only"
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}$",
+          "$comment": "YYYY-MM format"
+        },
+        {
+          "type": "string",
+          "pattern": "^([+-]?\\d{4,})(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01]))?)?$",
+          "$comment": "YYYY-MM-DDTHH:MM:SS format"
+        }
+      ]
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{1,2}:\\d{2}(:\\d{2})?(,\\d+)?$"
+    },
+    "timestampRange": {
+      "type": "string",
+      "pattern": "^\\d{1,2}:\\d{2}(:\\d{2})?(,\\d+)?-\\d{1,2}:\\d{2}(:\\d{2})?(,\\d+)?$"
+    },
+    "numericOrString": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "url": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            },
+            "date": {
+              "$ref": "#/definitions/date"
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "serialNumber": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "doi": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "issn": {
+              "type": "string"
+            },
+            "pmid": {
+              "type": "string"
+            },
+            "pmcid": {
+              "type": "string"
+            },
+            "arxiv": {
+              "type": "string"
+            },
+            "serial": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z]{2,3}(-[A-Z][a-z]{3,4})?(-[A-Z]{2})?$"
+    }
+  }
+}

--- a/hayagriva.schema.json
+++ b/hayagriva.schema.json
@@ -207,7 +207,6 @@
         },
         "serial-number": {
           "description": "Any serial number, including article numbers. If you have serial numbers of well-known schemes like `doi`, you should put them into the serial number as a dictionary. Hayagriva will recognize and specially treat `doi`, `isbn`, `issn`, `pmid`, `pmcid`, and `arxiv`. You can also include `serial` for the serial number when you provide other formats as well.",
-
           "$ref": "#/definitions/serialNumber"
         },
         "language": {
@@ -586,7 +585,6 @@
       "description": "Language of the entry.",
       "$comment": "Unicode Language Identifier (BCP 47).",
       "examples": ["zh-Hans"],
-
       "type": "string",
       "pattern": "^[a-z]{2,3}(-[A-Z][a-z]{3,4})?(-[A-Z]{2})?$"
     }

--- a/hayagriva.schema.json
+++ b/hayagriva.schema.json
@@ -18,7 +18,7 @@
             "author": "Rowling, J. K.",
             "volume": 5,
             "page-total": 768,
-            "date": "2003-06-21T00:00:00.000Z"
+            "date": "2003-06-21"
           }
         },
         {
@@ -28,6 +28,68 @@
             "serial-number": "v2.5",
             "author": "Ishkur",
             "url": "http://www.techno.org/electronic-music-guide/"
+          }
+        },
+        {
+          "kinetics": {
+            "type": "Article",
+            "title": "Kinetics and luminescence of the excitations of a nonequilibrium polariton condensate",
+            "author": ["Doan, T. D.", "Tran Thoai, D. B.", "Haug, Hartmut"],
+            "serial-number": {
+              "doi": "10.1103/PhysRevB.102.165126"
+            },
+            "page-range": "165126-165139",
+            "date": "2020-10-14",
+            "parent": {
+              "type": "Periodical",
+              "title": "Physical Review B",
+              "volume": 102,
+              "issue": 16,
+              "publisher": "American Physical Society"
+            }
+          }
+        },
+        {
+          "wwdc-network": {
+            "type": "Article",
+            "author": ["Mehta, Jiten", "Kinnear, Eric"],
+            "title": "Boost Performance and Security with Modern Networking",
+            "date": "2020-06-26",
+            "parent": [
+              {
+                "type": "Conference",
+                "title": "World Wide Developer Conference 2020",
+                "organization": "Apple Inc.",
+                "location": "Mountain View, CA"
+              },
+              {
+                "type": "Video",
+                "runtime": "00:13:42",
+                "url": "https://developer.apple.com/videos/play/wwdc2020/10111/"
+              }
+            ]
+          }
+        },
+        {
+          "plaque": {
+            "type": "Misc",
+            "title": "Informational plaque about Jacoby's 1967 photos",
+            "publisher": {
+              "name": "Stiftung Reinbeckhallen",
+              "location": "Berlin, Germany"
+            },
+            "date": 2020,
+            "parent": {
+              "type": "Artwork",
+              "date": 1967,
+              "author": "Jacoby, Max",
+              "parent": {
+                "type": "Anthology",
+                "title": "Bleibtreustraße",
+                "archive": "Landesmuseum Koblenz",
+                "archive-location": "Koblenz, Germany"
+              }
+            }
           }
         }
       ],
@@ -40,18 +102,7 @@
         },
         "author": {
           "description": "People primarily responsible for the creation of this entry",
-          "examples": [["Klocke, Iny", "Wohlrath, Elmar"]],
-          "oneOf": [
-            {
-              "$ref": "#/definitions/person"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/person"
-              }
-            }
-          ]
+          "$ref": "#/definitions/personOrList"
         },
         "date": {
           "description": "The date of publication or creation of this entry",
@@ -69,120 +120,113 @@
           "$ref": "#/definitions/parentOrArray"
         },
         "abstract": {
-          "$ref": "#/definitions/formattableString",
-          "description": "Abstract of the entry",
           "examples": [
             "The dominant sequence transduction models are based on complex..."
-          ]
+          ],
+          "$ref": "#/definitions/formattableString"
         },
         "genre": {
-          "description": "Type, class, or subtype of the item (e.g. \"Doctoral dissertation\" for a PhD thesis; \"NIH Publication\" for an NIH technical report). Do not use for topical descriptions or categories (e.g. \"adventure\" for an adventure movie)",
-          "$ref": "#/definitions/formattableString",
-          "examples": ["Doctoral dissertation"]
+          "description": "Type, class, or subtype of the item (e.g. \"Doctoral dissertation\" for a PhD thesis; \"NIH Publication\" for an NIH technical report). Do not use for topical descriptions or categories (e.g. \"adventure\" for an adventure movie).",
+          "examples": ["Doctoral dissertation"],
+          "$ref": "#/definitions/formattableString"
         },
         "editor": {
-          "description": "People responsible for selecting and revising the content of the entry",
-          "examples": ["Stringer, Gary A.", "Pebworth, Ted-Larry"],
+          "description": "People responsible for selecting and revising the content of the entry.",
           "$ref": "#/definitions/personOrList"
         },
         "affiliated": {
-          "description": "People involved with the entry that do not fit author or editor roles",
-          "examples": [
-            {
-              "role": "Director",
-              "names": "Cameron, James"
-            },
-            {
-              "role": "CastMember",
-              "names": [
-                "Schwarzenegger, Arnold",
-                "Hamilton, Linda",
-                "Patrick, Robert"
-              ]
-            }
-          ],
+          "description": "People involved with the entry that do not fit author or editor roles.",
           "$ref": "#/definitions/affiliatedList"
         },
         "call-number": {
-          "$ref": "#/definitions/formattableString",
-          "description": "The number of the item in a library, institution, or collection. Use with archive",
-          "examples": ["F16 D14"]
+          "description": "The number of the item in a library, institution, or collection. Use with archive.",
+          "examples": ["F16 D14"],
+          "$ref": "#/definitions/formattableString"
         },
         "publisher": {
-          "description": "The name of the publisher",
-          "examples": [
-            "Penguin Books",
-            {
-              "name": "Penguin Books",
-              "location": "London"
-            }
-          ],
+          "description": "The name of the publisher.",
           "$ref": "#/definitions/publisher"
         },
         "location": {
-          "$ref": "#/definitions/formattableString",
           "description": "Location at which the entry is physically located or took place. For the location where an item was published, use publisher instead.",
-          "examples": ["Lahore, Pakistan"]
+          "examples": ["Lahore, Pakistan"],
+          "$ref": "#/definitions/formattableString"
         },
         "organization": {
-          "description": "Organization at/for which the entry was produced",
+          "description": "Organization at/for which the entry was produced.",
           "examples": ["Technische Universität Berlin"],
           "$ref": "#/definitions/formattableString"
         },
         "issue": {
-          "$ref": "#/definitions/numericOrString",
-          "description": "For an entry whose parent has multiple issues, indicated the position in the issue sequence. Also used to indicate the episode number for TV",
-          "examples": [5]
+          "description": "For an entry whose parent has multiple issues, indicated the position in the issue sequence. Also used to indicate the episode number for TV.",
+          "examples": [5],
+          "$ref": "#/definitions/numericOrString"
         },
         "volume": {
-          "$ref": "#/definitions/numericOrString",
-          "description": "For an entry whose parent has multiple volumes, parts, seasons, etc. of which this entry is one",
-          "examples": ["2-3"]
+          "description": "For an entry whose parent has multiple volumes, parts, seasons, etc. of which this entry is one.",
+          "examples": ["2-3"],
+          "$ref": "#/definitions/numericOrString"
         },
         "volume-total": {
-          "type": "integer",
+          "description": "Total number of volumes, parts, seasons, etc. this entry is part of.",
           "examples": [12],
-          "description": "Total number of volumes, parts, seasons, etc. this entry is part of"
+          "type": "integer"
         },
         "edition": {
-          "$ref": "#/definitions/numericOrString",
-          "description": "Published version of the entry",
-          "examples": ["expanded and revised edition"]
+          "description": "Published version of the entry.",
+          "examples": ["expanded and revised edition"],
+          "$ref": "#/definitions/numericOrString"
         },
         "page-range": {
-          "$ref": "#/definitions/numericOrString",
-          "description": "Range of pages within the parent this entry occupies",
-          "examples": ["812-847"]
+          "description": "Range of pages within the parent this entry occupies.",
+          "examples": ["812-847"],
+          "$ref": "#/definitions/numericOrString"
         },
         "page-total": {
-          "type": "integer",
-          "description": "Total number of pages in the entry",
-          "examples": [768]
+          "description": "Total number of pages in the entry.",
+          "examples": [768],
+          "type": "integer"
         },
         "time-range": {
-          "description": "The time range within the parent this entry starts and ends at",
-          "examples": ["00:57-06:21"],
+          "description": "The time range within the parent this entry starts and ends at.",
           "$ref": "#/definitions/timestampRange"
         },
         "runtime": {
+          "description": "Total runtime of the entry.",
           "$ref": "#/definitions/timestamp"
         },
         "url": {
+          "description": "Canonical public URL of the entry, can have access date.",
+          "examples": [
+            {
+              "value": "https://www.reddit.com/r/AccidentalRenaissance/comments/er1uxd/japanese_opposition_members_trying_to_block_the/",
+              "date": "2020-12-29"
+            }
+          ],
           "$ref": "#/definitions/url"
         },
         "serial-number": {
+          "description": "Any serial number, including article numbers. If you have serial numbers of well-known schemes like `doi`, you should put them into the serial number as a dictionary. Hayagriva will recognize and specially treat `doi`, `isbn`, `issn`, `pmid`, `pmcid`, and `arxiv`. You can also include `serial` for the serial number when you provide other formats as well.",
+
           "$ref": "#/definitions/serialNumber"
         },
         "language": {
+          "description": "Language of the entry.",
           "$ref": "#/definitions/language"
         },
         "archive": {
+          "description": "Name of the institution/collection where the entry is kept.",
+          "examples": ["National Library of New Zealand"],
           "$ref": "#/definitions/formattableString"
         },
         "archive-location": {
+          "description": "Location of the institution/collection where the entry is kept.",
+          "examples": ["Wellington, New Zealand"],
           "$ref": "#/definitions/formattableString"
         },
         "note": {
+          "description": "Short markup, decoration, or annotation to the entry (e.g., to indicate items included in a review).",
+          "examples": ["microfilm version"],
           "$ref": "#/definitions/formattableString"
         }
       },
@@ -205,6 +249,13 @@
           },
           "required": ["name"],
           "additionalProperties": false
+        }
+      ],
+      "examples": [
+        "Penguin Books",
+        {
+          "name": "Penguin Books",
+          "location": "London"
         }
       ]
     },
@@ -260,13 +311,29 @@
     },
     "affiliatedList": {
       "type": "array",
+      "examples": [
+        {
+          "role": "Director",
+          "names": "Cameron, James"
+        },
+        {
+          "role": "CastMember",
+          "names": [
+            "Schwarzenegger, Arnold",
+            "Hamilton, Linda",
+            "Patrick, Robert"
+          ]
+        }
+      ],
       "items": {
         "type": "object",
         "properties": {
           "role": {
+            "description": "Role of the person in relation to the entry.",
             "$ref": "#/definitions/roleType"
           },
           "names": {
+            "description": "Names of the persons involved in the role.",
             "$ref": "#/definitions/personOrList"
           }
         },
@@ -301,7 +368,6 @@
       "pattern": "^(?i)(translator|afterword|foreword|introduction|annotator|commentator|holder|compiler|founder|collaborator|organizer|cast-member|composer|producer|executive-producer|writer|cinematography|director|illustrator|narrator)$"
     },
     "formattableString": {
-      "description": "A formattable string is a string that may run through a text case transformer when used in a reference or citation. You can disable these transformations on segments of the string or the whole string.",
       "oneOf": [
         {
           "type": "string"
@@ -313,12 +379,17 @@
               "type": "string"
             },
             "verbatim": {
-              "description": "",
+              "description": "If true, disables text case transformations.",
               "type": "boolean"
             },
             "short": {
+              "description": "Short form that a citation style can choose to render over the longer form.",
               "type": "string"
             }
+          },
+          "dependencies": {
+            "verbatim": ["value"],
+            "short": ["value"]
           },
           "required": ["value"]
         }
@@ -327,27 +398,45 @@
     "person": {
       "oneOf": [
         {
-          "type": "string"
+          "type": "string",
+          "examples": [
+            "Doe, Janet",
+            "Luther King, Martin, Jr.",
+            "UNICEF",
+            "von der Leyen, Ursula"
+          ]
         },
         {
           "type": "object",
           "properties": {
             "name": {
+              "description": "The family name of the person.",
               "type": "string"
             },
             "given-name": {
+              "description": "The given name of the person.",
               "type": "string"
             },
             "prefix": {
+              "description": "The prefix of the person's name.",
               "type": "string"
             },
             "suffix": {
+              "description": "The suffix of the person's name.",
               "type": "string"
             },
             "alias": {
+              "description": "An alias for the person.",
               "type": "string"
             }
           },
+          "examples": [
+            {
+              "given-name": "Gloria Jean",
+              "name": "Watkins",
+              "alias": "bell hooks"
+            }
+          ],
           "required": ["name"],
           "additionalProperties": false
         }
@@ -367,39 +456,50 @@
       ]
     },
     "date": {
+      "description": "A calendar date as ISO 8601.",
       "anyOf": [
-        {
-          "type": "string",
-          "format": "date",
-          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-          "$comment": "YYYY-MM-DD format"
-        },
         {
           "type": "integer",
           "minimum": 0,
-          "$comment": "Year only"
+          "examples": [2003],
+          "description": "Shortened date for year only."
         },
         {
           "type": "string",
-          "pattern": "^\\d{4}-\\d{2}$",
-          "$comment": "YYYY-MM format"
-        },
-        {
-          "type": "string",
-          "pattern": "^([+-]?\\d{4,})(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01]))?)?$",
-          "$comment": "YYYY-MM-DDTHH:MM:SS format"
+          "format": "date",
+          "$comment": "ISO 8601 date format (YYYY-MM-DD | YYYY-MM | YYYY).",
+          "examples": ["2003-06-21", "2003-06", "2003"],
+          "pattern": "^([+-]?\\d{4,})(-(0[1-9]|1[0-2])(-(0[1-9]|[12][0-9]|3[01]))?)?$"
         }
       ]
     },
     "timestamp": {
+      "description": "A timestamp represents some time in a piece of media. It is given as a string of the form DD:HH:MM:SS,msms but everything except MM:SS can be omitted. Wrapping the string in double-quotes is necessary due to the colons.",
       "type": "string",
-      "pattern": "^\\d{1,2}:\\d{2}(:\\d{2})?(,\\d+)?$"
+      "examples": [
+        "12:34",
+        "1:12:34",
+        "2:01:12:34",
+        "12:34,567",
+        "1:12:34,567",
+        "2:01:12:34,567"
+      ],
+      "pattern": "^((\\d{1,2}:)?([0-5]?\\d:))?([0-5]?\\d):([0-5]\\d)(,\\d+)?$"
     },
     "timestampRange": {
+      "description": "A range of timestamps is a string containing two timestamps separated by a hyphen.",
       "type": "string",
-      "pattern": "^\\d{1,2}:\\d{2}(:\\d{2})?(,\\d+)?-\\d{1,2}:\\d{2}(:\\d{2})?(,\\d+)?$"
+      "examples": [
+        "00:12-00:34",
+        "1:00:12-1:00:34",
+        "2:01:12:34-2:01:12:56",
+        "00:12,567-00:34,890",
+        "1:00:12,567-1:00:34,890"
+      ],
+      "pattern": "^((\\d{1,2}:)?([0-5]?\\d:)?([0-5]?\\d):([0-5]\\d)(,\\d+)?)-((\\d{1,2}:)?([0-5]?\\d:)?([0-5]?\\d):([0-5]\\d)(,\\d+)?)$"
     },
     "numericOrString": {
+      "description": "A numeric or string value.",
       "oneOf": [
         {
           "type": "number"
@@ -410,6 +510,7 @@
       ]
     },
     "url": {
+      "description": "Canonical public URL of the entry, can have access date.",
       "oneOf": [
         {
           "type": "string"
@@ -418,9 +519,11 @@
           "type": "object",
           "properties": {
             "value": {
+              "description": "The URL value.",
               "type": "string"
             },
             "date": {
+              "description": "The access date of the URL.",
               "$ref": "#/definitions/date"
             }
           },
@@ -430,32 +533,48 @@
       ]
     },
     "serialNumber": {
+      "description": "Any serial number, including article numbers. If you have serial numbers of well-known schemes like `doi`, you should put them into the serial number as a dictionary. Hayagriva will recognize and specially treat `doi`, `isbn`, `issn`, `pmid`, `pmcid`, and `arxiv`. You can also include `serial` for the serial number when you provide other formats as well.",
       "oneOf": [
         {
           "type": "string"
         },
         {
           "type": "object",
+          "examples": [
+            "2003.13722",
+            {
+              "doi": "10.22541/au.148771883.35456290",
+              "arxiv": "1906.00356",
+              "serial": "8516"
+            }
+          ],
           "properties": {
             "doi": {
+              "description": "Digital Object Identifier.",
               "type": "string"
             },
             "isbn": {
+              "description": "International Standard Book Number.",
               "type": "string"
             },
             "issn": {
+              "description": "International Standard Serial Number.",
               "type": "string"
             },
             "pmid": {
+              "description": "PubMed Identifier.",
               "type": "string"
             },
             "pmcid": {
+              "description": "PubMed Central Identifier.",
               "type": "string"
             },
             "arxiv": {
+              "description": "arXiv Identifier.",
               "type": "string"
             },
             "serial": {
+              "description": "Serial number.",
               "type": "string"
             }
           },
@@ -464,6 +583,10 @@
       ]
     },
     "language": {
+      "description": "Language of the entry.",
+      "$comment": "Unicode Language Identifier (BCP 47).",
+      "examples": ["zh-Hans"],
+
       "type": "string",
       "pattern": "^[a-z]{2,3}(-[A-Z][a-z]{3,4})?(-[A-Z]{2})?$"
     }


### PR DESCRIPTION
Example used for validation (using [JSON Schema Validator](https://www.jsonschemavalidator.net/)):

```yaml
harry:
  type: Book
  title: Harry Potter and the Order of the Phoenix
  author: Rowling, J. K.
  volume: 5
  page-total: 768
  date: 2003-06-21

electronic:
  type: Web
  title: Ishkur's Guide to Electronic Music
  serial-number: v2.5
  author: Ishkur
  url: http://www.techno.org/electronic-music-guide/

kinetics:
  type: Article
  title: Kinetics and luminescence of the excitations of a nonequilibrium polariton condensate
  author: ["Doan, T. D.", "Tran Thoai, D. B.", "Haug, Hartmut"]
  serial-number:
    doi: "10.1103/PhysRevB.102.165126"
  page-range: 165126-165139
  date: 2020-10-14
  parent:
    type: Periodical
    title: Physical Review B
    volume: 102
    issue: 16
    publisher: American Physical Society

wwdc-network:
  type: Article
  author: ["Mehta, Jiten", "Kinnear, Eric"]
  title: Boost Performance and Security with Modern Networking
  date: 2020-06-26
  parent:
    - type: Conference
      title: World Wide Developer Conference 2020
      organization: Apple Inc.
      location: Mountain View, CA
    - type: Video
      runtime: "00:13:42"
      url: https://developer.apple.com/videos/play/wwdc2020/10111/

plaque:
  type: Misc
  title: Informational plaque about Jacoby's 1967 photos
  publisher:
    name: Stiftung Reinbeckhallen
    location: Berlin, Germany
  date: 2020
  parent:
    type: Artwork
    date: 1967
    author: Jacoby, Max
    parent:
      type: Anthology
      title: Bleibtreustraße
      archive: Landesmuseum Koblenz
      archive-location: Koblenz, Germany
```

`$id` would need to be added.