### PR TITLE
Propagate font-variant from name element to name parts

### DIFF
--- a/src/csl/rendering/names.rs
+++ b/src/csl/rendering/names.rs
@@ -596,25 +596,11 @@ fn write_name<T: EntryLike>(
 
     // Combine the name formatting with specific part formatting
     let first_format = first_part
-        .map(|p| {
-            let mut fmt = p.formatting;
-            // If the name has font-variant set but the part doesn't, inherit it
-            if name_formatting.font_variant.is_some() && fmt.font_variant.is_none() {
-                fmt.font_variant = name_formatting.font_variant;
-            }
-            fmt
-        })
+        .map(|p| p.formatting.apply(name_formatting))
         .unwrap_or(name_formatting);
 
     let family_format = family_part
-        .map(|p| {
-            let mut fmt = p.formatting;
-            // If the name has font-variant set but the part doesn't, inherit it
-            if name_formatting.font_variant.is_some() && fmt.font_variant.is_none() {
-                fmt.font_variant = name_formatting.font_variant;
-            }
-            fmt
-        })
+        .map(|p| p.formatting.apply(name_formatting))
         .unwrap_or(name_formatting);
 
     let first_case = first_part.map(|p| p.text_case).unwrap_or_default();

--- a/src/csl/rendering/names.rs
+++ b/src/csl/rendering/names.rs
@@ -588,15 +588,40 @@ fn write_name<T: EntryLike>(
     let hyphen_init = ctx.style.csl.settings.initialize_with_hyphen;
     let sort_sep = name_opts.sort_separator;
 
+    // Get the formatting from the name element itself
+    let name_formatting = cs_name.formatting;
+
     let first_part = cs_name.name_part_given();
     let family_part = cs_name.name_part_family();
-    let first_format = first_part.map(|p| p.formatting).unwrap_or_default();
+
+    // Combine the name formatting with specific part formatting
+    let first_format = first_part
+        .map(|p| {
+            let mut fmt = p.formatting;
+            // If the name has font-variant set but the part doesn't, inherit it
+            if name_formatting.font_variant.is_some() && fmt.font_variant.is_none() {
+                fmt.font_variant = name_formatting.font_variant;
+            }
+            fmt
+        })
+        .unwrap_or(name_formatting);
+
+    let family_format = family_part
+        .map(|p| {
+            let mut fmt = p.formatting;
+            // If the name has font-variant set but the part doesn't, inherit it
+            if name_formatting.font_variant.is_some() && fmt.font_variant.is_none() {
+                fmt.font_variant = name_formatting.font_variant;
+            }
+            fmt
+        })
+        .unwrap_or(name_formatting);
+
     let first_case = first_part.map(|p| p.text_case).unwrap_or_default();
     let first_affixes = [
         first_part.map(|p| &p.affixes).and_then(|f| f.prefix.as_ref()),
         first_part.map(|p| &p.affixes).and_then(|f| f.suffix.as_ref()),
     ];
-    let family_format = family_part.map(|p| p.formatting).unwrap_or_default();
     let family_case = family_part.map(|p| p.text_case).unwrap_or_default();
     let family_affixes = [
         family_part.map(|p| &p.affixes).and_then(|f| f.prefix.as_ref()),

--- a/src/csl/rendering/names.rs
+++ b/src/csl/rendering/names.rs
@@ -367,7 +367,9 @@ impl RenderCsl for Names {
             }
 
             do_label(NameLabelPosition::BeforeName, ctx);
+            let idx = ctx.push_format(cs_name.formatting);
             add_names(self, ctx, persons, &cs_name, forms, variable);
+            ctx.pop_format(idx);
             do_label(NameLabelPosition::AfterName, ctx);
         }
 
@@ -588,26 +590,15 @@ fn write_name<T: EntryLike>(
     let hyphen_init = ctx.style.csl.settings.initialize_with_hyphen;
     let sort_sep = name_opts.sort_separator;
 
-    // Get the formatting from the name element itself
-    let name_formatting = cs_name.formatting;
-
     let first_part = cs_name.name_part_given();
     let family_part = cs_name.name_part_family();
-
-    // Combine the name formatting with specific part formatting
-    let first_format = first_part
-        .map(|p| p.formatting.apply(name_formatting))
-        .unwrap_or(name_formatting);
-
-    let family_format = family_part
-        .map(|p| p.formatting.apply(name_formatting))
-        .unwrap_or(name_formatting);
-
+    let first_format = first_part.map(|p| p.formatting).unwrap_or_default();
     let first_case = first_part.map(|p| p.text_case).unwrap_or_default();
     let first_affixes = [
         first_part.map(|p| &p.affixes).and_then(|f| f.prefix.as_ref()),
         first_part.map(|p| &p.affixes).and_then(|f| f.suffix.as_ref()),
     ];
+    let family_format = family_part.map(|p| p.formatting).unwrap_or_default();
     let family_case = family_part.map(|p| p.text_case).unwrap_or_default();
     let family_affixes = [
         family_part.map(|p| &p.affixes).and_then(|f| f.prefix.as_ref()),

--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -9,6 +9,7 @@ affix_TextNodeWithMacro
 bugreports_Abnt
 bugreports_ArabicLocale
 bugreports_AsaSpacing
+bugreports_AsmJournals
 bugreports_AuthorYear
 bugreports_BadCitationUpdate
 bugreports_ChineseCharactersFamilyOnlyPluralLabel

--- a/tests/citeproc.rs
+++ b/tests/citeproc.rs
@@ -625,7 +625,9 @@ where
 mod citeproc_bib {
     use core::fmt;
 
-    use citationberg::{Display, FontStyle, FontVariant, FontWeight, VerticalAlign};
+    use citationberg::{
+        Display, FontStyle, FontVariant, FontWeight, TextDecoration, VerticalAlign,
+    };
     use hayagriva::{BufWriteFormat, Elem, ElemChild, Formatting};
 
     pub(super) fn render(
@@ -739,6 +741,13 @@ mod citeproc_bib {
         match formatting.font_variant {
             FontVariant::SmallCaps => css.push_str("font-variant:small-caps;"),
             FontVariant::Normal => {}
+        }
+
+        match formatting.text_decoration {
+            // NOTE: No existing citeproc tests use this, so this is guesswork.
+            // However, we can use this in local tests.
+            TextDecoration::Underline => push_elem("<u>", "</u>"),
+            TextDecoration::None => {}
         }
 
         if !css.is_empty() {

--- a/tests/local/name_PartInheritsFormatting.txt
+++ b/tests/local/name_PartInheritsFormatting.txt
@@ -1,0 +1,93 @@
+
+>>===== MODE =====>>
+bibliography
+<<===== MODE =====<<
+
+
+
+>>===== RESULT =====>>
+<div class="csl-bib-body">
+  <div class="csl-entry">
+    <b>Doe Co.</b>
+    <span style="font-variant:small-caps;">Doe Co.</span>
+    <i>Doe Co.</i>
+    <i>Doe Co.</i>
+    <b><i><span style="font-variant:small-caps;">Doe Co.</span></i></b>
+    <sup><b><i><u><span style="font-variant:small-caps;">Doe Co.</span></u></i></b></sup>
+  </div>
+</div>
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
+   <info>
+      <id />
+      <title />
+      <updated>2009-08-10T04:49:00+09:00</updated>
+   </info>
+   <citation>
+      <layout>
+        <text value="Bib only" />
+      </layout>
+   </citation>
+   <bibliography>
+      <layout>
+        <names variable="author">
+          <name font-weight="bold"/>
+        </names>
+        <names variable="author">
+          <name font-variant="small-caps"/>
+        </names>
+        <names variable="author">
+          <name font-style="italic"/>
+        </names>
+        <names variable="author" font-style="italic">
+          <name/>
+        </names>
+        <names variable="author">
+          <name font-weight="bold" font-variant="small-caps" >
+            <name-part name="family" font-style="italic"/>
+          </name>
+        </names>
+        <names variable="author">
+          <name font-style="italic" text-decoration="underline" vertical-align="sup">
+            <name-part name="family" font-weight="bold" font-variant="small-caps"/>
+          </name>
+        </names>
+      </layout>
+   </bibliography>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "author": [
+            {
+                "family": "Doe Co.",
+                "isInstitution": true
+            }
+        ],
+        "id": "ITEM-1",
+        "issued": {
+            "date-parts": [
+                [
+                    "1965",
+                    "6",
+                    "1"
+                ]
+            ]
+        },
+        "title": "His Collectively Anonymous Life",
+        "type": "book"
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
When using font-variant="small-caps" on the <name> element in CSL styles, this formatting wasn't properly inherited by the individual name parts, causing the styling to be ignored. This fix ensures that font-variant styling is correctly propagated from the parent <name> element to child name parts (given name and family name) while maintaining the behavior where connector words like "and" remain in normal text.

This allows for proper small-caps styling of author names in bibliography styles like IEEE while keeping connector words in regular formatting.

![image](https://github.com/user-attachments/assets/275f2b2b-97b0-4efb-86a5-db634aacf075)

Fixes #175.