### PR TITLE
Run archiver tests weekly instead of on CI

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,22 @@
+name: Weekly archive up-to-date check
+on:
+  schedule:
+    - cron: 00 3 * * 1
+  workflow_dispatch:
+
+env:
+  RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check out CSL styles
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/citation-style-language/styles
+      - name: Check if archives are up-to-date
+        run: cargo test --test archiver -- --ignored

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: 00 3 * * 1
   workflow_dispatch:
+  release:
+    # Run on draft and final releases
+    types: [published]
 
 env:
   RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Check out CSL styles
-        run: |
-          cd ..
-          git clone --depth 1 https://github.com/citation-style-language/styles
       - run: cargo build
       - run: cargo test --features csl-json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.0
+      - uses: dtolnay/rust-toolchain@1.83.0
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2

--- a/tests/archiver.rs
+++ b/tests/archiver.rs
@@ -43,7 +43,7 @@ const UPDATE_ARCHIVES_ENV_VAR: &str = "HAYAGRIVA_ARCHIVER_UPDATE";
 /// below:
 ///
 /// ```sh
-/// cargo test -- always-archive --ignored
+/// cargo test --test archiver -- --ignored
 /// ```
 #[test]
 #[ignore]

--- a/tests/archiver.rs
+++ b/tests/archiver.rs
@@ -34,8 +34,19 @@ const ARCHIVE_STYLES_PATH: &str = "archive/styles/";
 const ARCHIVE_LOCALES_PATH: &str = "archive/locales/";
 const ARCHIVE_SRC_PATH: &str = "src/csl/archive.rs";
 
-/// Always archive.
+const UPDATE_ARCHIVES_ENV_VAR: &str = "HAYAGRIVA_ARCHIVER_UPDATE";
+
+/// Always archive CSL styles from upstream.
+///
+/// Ignore by default so CI and tests can pass despite outdated archives.
+/// This specific test should rather be run periodically using the command
+/// below:
+///
+/// ```sh
+/// cargo test -- always-archive --ignored
+/// ```
 #[test]
+#[ignore]
 fn always_archive() {
     ensure_repos().unwrap_or_else(|err| panic!("Downloading repos failed: {}", err));
     create_archive().unwrap_or_else(|err| panic!("{}", err));
@@ -106,7 +117,7 @@ fn create_archive() -> Result<(), ArchivalError> {
     // Without "HAYAGRIVA_ARCHIVER_UPDATE=1", we only check if the archive
     // files are up-to-date.
     let should_write =
-        std::env::var_os("HAYAGRIVA_ARCHIVER_UPDATE").is_some_and(|var| var == "1");
+        std::env::var_os(UPDATE_ARCHIVES_ENV_VAR).is_some_and(|var| var == "1");
 
     let mut w = String::new();
     let mut styles: Vec<_> = iter_files(&style_path, "csl")
@@ -453,8 +464,7 @@ impl fmt::Display for ArchivalError {
             Self::NeedsUpdate(item) => {
                 write!(
                     f,
-                    "{} is outdated, run archiver tests with env var 'HAYAGRIVA_ARCHIVER_UPDATE=1' to update",
-                    item
+                    "{item} is outdated, run archiver tests with env var '{UPDATE_ARCHIVES_ENV_VAR}=1' to update",
                 )
             }
         }


### PR DESCRIPTION
Should avoid PRs wrongfully failing CI.

Also bumps Rust toolchain version on CI to Rust 1.83.0 since our deps have bumped their versions.