### PR TITLE
biblatex `type` to `genre`, `number` to `serial` for non-article.

### DIFF
--- a/src/interop.rs
+++ b/src/interop.rs
@@ -393,6 +393,13 @@ impl TryFrom<&tex::Entry> for Entry {
             }
         }
 
+        // "number" is generally used in Biblatex for "The number of a journal
+        // or the volume/number of a book in a series".  However, it is also
+        // used for patent entries as "the number or record token of a patent
+        // or patent request", and is also listed as an optional field for
+        // report, manual, and dataset, where it fits the use for patent.
+        // Hayagriva uses "issue" for the journal/book sense of biblatex's number,
+        // and "serial-number" for the record number / token sense.
         if let Some(number) = map_res(entry.number())?.map(|d| d.into()) {
             if let Some(parent) = book(&mut item, parent) {
                 parent.set_issue(number);
@@ -566,6 +573,11 @@ impl TryFrom<&tex::Entry> for Entry {
             item.set_abstract_(abstract_.into())
         }
 
+        // BibLaTeX describes "type" as "The type of a manual, patent, report, or thesis.
+        // This field may also be useful for the custom types listed in § 2.1.3."
+        // Hayagriva uses "genre" for 'Type, class, or subtype of the item (e.g.
+        // "Doctoral dissertation" for a PhD thesis; "NIH Publication" for an NIH
+        // technical report)'
         if let Some(type_) = map_res(entry.type_())? {
             item.set_genre(type_.into());
         }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -397,7 +397,15 @@ impl TryFrom<&tex::Entry> for Entry {
             if let Some(parent) = book(&mut item, parent) {
                 parent.set_issue(number);
             } else {
-                item.set_issue(number);
+                match item.entry_type {
+                    EntryType::Report
+                    | EntryType::Patent
+                    | EntryType::Entry
+                    | EntryType::Reference => {
+                        item.set_keyed_serial_number("serial", number.to_string())
+                    }
+                    _ => item.set_issue(number),
+                }
             }
         }
 
@@ -556,6 +564,10 @@ impl TryFrom<&tex::Entry> for Entry {
 
         if let Some(abstract_) = map_res(entry.abstract_())? {
             item.set_abstract_(abstract_.into())
+        }
+
+        if let Some(type_) = map_res(entry.type_())? {
+            item.set_genre(type_.into());
         }
 
         if let Some(series) = map_res(entry.series())? {


### PR DESCRIPTION
This is meant to close #295 :

The `type` field (not entry type) in biblatex is used to set `genre`, regardless of entry type.  I think this is appropriate for all uses of `type`; biblatex's documentation states `type` is "The type of a manual, patent, report, or thesis. This field may also be useful for the custom types listed in § 2.1.3.", while Hayagriva's file format states `genre` is "Type, class, or subtype of the item (e.g. "Doctoral dissertation" for a PhD thesis; "NIH Publication" for an NIH technical report). Do not use for topical descriptions or categories (e.g. "adventure" for an adventure movie).".

The `number` field is more of a problem.  Biblatex's documentation describes it as "The number of a journal or the volume/number of a book in a series."  However, it then goes on to say "With `@patent` entries, this is the number or record token of a patent or patent request", and, not documented in the description of `number`, is listed as an optional field in several entry types that seem more likely to be using it as a CSL number / Hayagriva serial-number than an issue number, namely report, manual, and dataset.  So I'm not quite sure what the best handling here is.   

I've done what seems to be to be the minimal change, which is to set serial-number for Repository, Reference, Patent, and Report, the Hayagriva types corresponding to the biblatex types that list number as an optional field where serial-number seems to make more sense.  But I wonder whether non-default styles also use it for other types, eg, Manuscript, Thesis, etc? 

