### PR TITLE
Add ID to `LocatorPayload::Transparent`

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -2251,7 +2251,11 @@ pub enum LocatorPayload<'a> {
     Str(&'a str),
     /// An element with the original index of the locator will be yielded. The
     /// consumer can then recognize this and replace it with their own content.
-    Transparent,
+    ///
+    /// Each `Transparent` locator has associated numeric ID. Transparent
+    /// locators with the same ID are considered identical, and with different
+    /// ID are considered different.
+    Transparent(u32),
 }
 
 impl<'a, T: EntryLike> Context<'a, T> {

--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -64,7 +64,7 @@ impl<'a, T: EntryLike> InstanceContext<'a, T> {
                         .map(|n| MaybeTyped::Typed(Cow::Owned(n)))
                         .unwrap_or_else(|_| MaybeTyped::String(l.to_owned())),
                 )),
-                LocatorPayload::Transparent => Some(NumberVariableResult::Transparent(
+                LocatorPayload::Transparent(_) => Some(NumberVariableResult::Transparent(
                     self.cite_props.certain.initial_idx,
                 )),
             },


### PR DESCRIPTION
This way we can pass information about transparent locator payloads being the same or different,
and thanks to it generate correct `ibid` vs `ibid-with-locator` states.