### PR TITLE
Add arXiv identifier

### DIFF
--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -70,6 +70,17 @@ impl RenderCsl for citationberg::Text {
                     let url = format!("https://doi.org/{}", val.to_str());
                     ctx.push_link(&val, url);
                 }
+                StandardVariable::ARXIV => {
+                    let printed_val = val.to_str();
+                    // The arXiv ID can be in two formats:
+                    //  - pre 2007: "hep-th/9603067"
+                    //  - post 2007: "2412.11645 [hep-ex]"
+                    // We only want the first part for the url.
+                    let id = printed_val.split(' ').next().unwrap_or_default();
+                    let url =
+                        format!("https://arxiv.org/abs/{}", id);
+                    ctx.push_link(&val, url);
+                }
                 StandardVariable::PMID => {
                     let url =
                         format!("https://www.ncbi.nlm.nih.gov/pubmed/{}", val.to_str());

--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -330,6 +330,9 @@ impl EntryLike for Entry {
                 .map(|f| f.select(form))
                 .map(Cow::Borrowed),
             StandardVariable::PartTitle => None,
+            StandardVariable::ARXIV => {
+                entry.arxiv().map(|d| Cow::Owned(StringChunk::verbatim(d).into()))
+            }
             StandardVariable::PMCID => {
                 entry.pmcid().map(|d| Cow::Owned(StringChunk::verbatim(d).into()))
             }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -452,6 +452,19 @@ impl TryFrom<&tex::Entry> for Entry {
                 map_res(entry.eprint_type().map(|c| c.format_verbatim().to_lowercase()))?;
             let eprint_type = eprint_type.as_deref();
             if eprint_type == Some("arxiv") {
+                let eprint_class = map_res(entry.eprint_class())
+                    .map(|c| c.map(|s| s.format_verbatim()))
+                    .unwrap_or(None);
+
+                // arXiv identifiers come in two forms:
+                //  - pre 2007: `arXiv:hep-th/9603067`
+                //  - post 2007: `arXiv:2412.11645 [hep-ex]`
+                let eprint = match eprint_class {
+                    Some(class) if !eprint.contains(&class) => {
+                        format!("{} [{}]", eprint, class)
+                    }
+                    _ => eprint,
+                };
                 item.set_arxiv(eprint);
             } else if eprint_type == Some("pubmed") {
                 item.set_pmid(eprint);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,38 @@ use hayagriva::{
 };
 use hayagriva::{BibliographyRequest, Selector};
 
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CliError {
+    #[error("No bibliography found in the style.")]
+    NoBibliography,
+
+    #[error("Bibliography file {0} not found.")]
+    BibliographyFileNotFound(String),
+
+    #[error("Error while reading the bibliography file: {0}")]
+    BibliographyRead(String),
+
+    #[error("Error while parsing selector: {0}")]
+    SelectorParse(#[from] hayagriva::SelectorError),
+
+    #[error("Error while serializing to YAML: {0}")]
+    SerializeYaml(#[from] serde_yaml::Error),
+}
+
+impl CliError {
+    pub fn code(&self) -> i32 {
+        match self {
+            CliError::NoBibliography => 4,
+            CliError::BibliographyFileNotFound(_) => 5,
+            CliError::BibliographyRead(_) => 6,
+            CliError::SelectorParse(_) => 7,
+            CliError::SerializeYaml(_) => 8,
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, VariantNames)]
 #[strum(serialize_all = "kebab_case")]
 pub enum Format {
@@ -51,8 +83,7 @@ impl ValueEnum for Format {
     }
 }
 
-/// Main function of the Hayagriva CLI.
-fn main() {
+fn run() -> Result<(), CliError> {
     let matches = Command::new("Hayagriva CLI")
             .version(crate_version!())
             .author("The Typst Project Developers <hi@typst.app>")
@@ -207,28 +238,22 @@ fn main() {
     });
 
     let bibliography = {
-        let input = match read_to_string(input) {
-            Ok(s) => s,
-            Err(e) => {
-                if e.kind() == IoErrorKind::NotFound {
-                    eprintln!("Bibliography file \"{}\" not found.", input.display());
-                    exit(5);
-                } else if let Some(os) = e.raw_os_error() {
-                    eprintln!(
-                        "Error while reading the bibliography file \"{}\": {}",
-                        input.display(),
-                        os
-                    );
-                    exit(6);
-                } else {
-                    eprintln!(
-                        "Error while reading the bibliography file \"{}\".",
-                        input.display()
-                    );
-                    exit(6);
-                }
+        let input = read_to_string(input).map_err(|e| {
+            if e.kind() == IoErrorKind::NotFound {
+                CliError::BibliographyFileNotFound(input.display().to_string())
+            } else if let Some(os) = e.raw_os_error() {
+                CliError::BibliographyRead(format!(
+                    "Error while reading the bibliography file \"{}\": {}",
+                    input.display(),
+                    os
+                ))
+            } else {
+                CliError::BibliographyRead(format!(
+                    "Error while reading the bibliography file \"{}\".",
+                    input.display()
+                ))
             }
-        };
+        })?;
 
         match format {
             Format::Yaml => io::from_yaml_str(&input).unwrap(),
@@ -239,17 +264,10 @@ fn main() {
 
     let bib_len = bibliography.len();
 
-    let selector =
-        matches
-            .get_one("selector")
-            .cloned()
-            .map(|src| match Selector::parse(src) {
-                Ok(selector) => selector,
-                Err(err) => {
-                    eprintln!("Error while parsing selector: {err}");
-                    exit(7);
-                }
-            });
+    // Try to parse the selector if provided
+    let selector = matches.get_one("selector").cloned().map_or(Ok(None), |src| {
+        Selector::parse(src).map(Some).map_err(CliError::SelectorParse)
+    })?;
 
     let bibliography = if let Some(keys) = matches.get_one::<String>("key") {
         let mut res = vec![];
@@ -306,7 +324,7 @@ fn main() {
                 }
             }
         }
-        exit(0);
+        return Ok(());
     }
 
     match matches.subcommand() {
@@ -321,8 +339,7 @@ fn main() {
                 retrieve_assets(style, csl, locale_path, locale_str);
 
             if style.bibliography.is_none() {
-                eprintln!("style has no bibliography");
-                exit(4);
+                return Err(CliError::NoBibliography);
             }
 
             let mut driver = BibliographyDriver::new();
@@ -448,10 +465,11 @@ fn main() {
             }
         }
         _ => {
-            let bib = io::to_yaml_str(&bibliography).unwrap();
+            let bib = io::to_yaml_str(&bibliography)?;
             println!("{bib}");
         }
     }
+    Ok(())
 }
 
 fn retrieve_assets<'a>(
@@ -491,4 +509,13 @@ fn retrieve_assets<'a>(
     };
 
     (style, locales, locale)
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {}", e);
+        exit(e.code());
+    }
+
+    exit(0);
 }

--- a/tests/data/lotr.bib
+++ b/tests/data/lotr.bib
@@ -1,9 +1,0 @@
-@book{tolkien54,
-    maintitle = {The Lord of the Rings},
-    title = {The Fellowship of the Ring},
-    author = {J. R. R. Tolkien},
-    date = {1954-07-29},
-    publisher = {Allen & Unwin},
-    location = {London},
-    volume = {1},
-}


### PR DESCRIPTION
## Summary

Adds an arXiv identifier `ARXIV` similar to `PMID`, `PMCID` and `DOI`.

Makes it possible to add the [recommended form of citing arXiv submissions](https://info.arxiv.org/help/faq/references.html) to a bibliography template with `<text variable="ARXIV" prefix="arXiv:"/>`.

## Context
The arXiv references come in two forms
- pre 2007:  `arXiv:hep-th/9603067`
- post 2007: `arXiv:2412.11645 [hep-ex]`

where the identifier itself can also have a version, e.g. `2412.11645v2`.

See also the [biblatex manual](https://ftp.rrzn.uni-hannover.de/pub/mirror/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf) section "3.14.7 Electronic Publishing Information", which basically says that arXiv submissions are given in their format as

```
eprint = {identifier},
eprinttype = {arxiv},
eprintclass = {class},
```
with a few aliases like `primaryclass` for `eprintclass` which are already implemented in https://github.com/typst/biblatex/pull/75 but are not yet in the published release.

## Related discussions
- https://github.com/typst/hayagriva/issues/302
- https://github.com/typst/typst/discussions/3006
- https://forum.typst.app/t/how-can-i-show-the-arxiv-identifier-in-the-bibliography/3330
- https://discord.com/channels/1054443721975922748/1088371919725793360/1337798216632242186
- https://discord.com/channels/1054443721975922748/1088371919725793360/1111970697837809735
- https://discord.com/channels/1054443721975922748/1088371919725793360/1090915615142846494


## The actual change
Before this PR a hayagriva import of a bibtex file ignores the eprintclass and saves only the identifier as a serial number. Neither class or identifier are accessible from the CSL styles. After this PR the class is also added to the arXiv serial number but it still works without the class.
```
serial-number:
  - arxiv: '{identifier} [{class}]'
```

For the tests I added it to the end of the APS style, which looks like this

>[1] R. Aaij others, Test of lepton flavor universality with B^+ arrow K^+ pi^+ pi^- ell^+ ell^- decays, Phys. Rev. Lett. 134, 181803 (2025), arXiv:2412.11645 [hep-ex].
>[2] N. Itzhaki, Some remarks on 't Hooft's S-matrix for black holes, (1996), arXiv:hep-th/9603067.


First two commits are the discussed changes and I sneaked in two "cleanup" commits. One deletes an unused file in the tests folder and the other one adds custom error types for the cli.


Fixes https://github.com/typst/hayagriva/issues/302.
Depends on https://github.com/typst/biblatex/pull/75 and https://github.com/typst/citationberg/pull/24.