### PR TITLE
Fix negative year rendering

### DIFF
--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -731,9 +731,7 @@ fn render_date_part<T: EntryLike>(
     let Some(val) = (match date_part.name {
         DatePartName::Day => date.day.map(|i| i as i32 + 1),
         DatePartName::Month => date.month.map(|i| i as i32 + 1),
-        DatePartName::Year => {
-            Some(if date.year > 0 { date.year } else { date.year.abs() + 1 })
-        }
+        DatePartName::Year => Some(date.year),
     }) else {
         return;
     };

--- a/tests/local/date_DateBCAdjusted.txt
+++ b/tests/local/date_DateBCAdjusted.txt
@@ -1,0 +1,56 @@
+>>===== MODE =====>>
+citation
+<<===== MODE =====<<
+
+
+
+
+>>===== RESULT =====>>
+(251BC)
+<<===== RESULT =====<<
+
+
+>>===== CSL =====>>
+<style
+      xmlns="http://purl.org/net/xbiblio/csl"
+      class="note"
+      version="1.0">
+  <info>
+    <id />
+    <title />
+    <updated>2009-08-10T04:49:00+09:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <date prefix="(" suffix=")" variable="issued">
+        <date-part form="long" name="month" />
+        <date-part name="day" suffix=", " />
+        <date-part name="year" />
+      </date>
+    </layout>
+  </citation>
+</style>
+<<===== CSL =====<<
+
+
+>>===== INPUT =====>>
+[
+    {
+        "id": "ITEM-1",
+        "issued": {
+            "date-parts": [
+                [
+                    -250
+                ]
+            ]
+        },
+        "title": "Ignore me",
+        "type": "book"
+    }
+]
+<<===== INPUT =====<<
+
+
+>>===== VERSION =====>>
+1.0
+<<===== VERSION =====<<


### PR DESCRIPTION
Fixes #333.

A regression from #235, fixed by this PR, caused negative years to always be displayed as AD instead of BC.

Thanks to @Enivex for suggesting the fix.