### PR TITLE
Use locale terms for AD/BC

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -635,7 +635,14 @@ fn date_replacement<T: EntryLike>(
     ElemChildren(vec![ElemChild::Text(Formatted {
         text: if let Some(date) = date {
             let mut s = String::with_capacity(4);
-            write_year(date.year, false, &mut s).unwrap();
+            let c = ctx.ctx(entry, cite_props.clone(), locale, term_locale, false);
+            let ad = c
+                .term(Term::Other(OtherTerm::Ad), TermForm::default(), false)
+                .unwrap_or(" AD");
+            let bc = c
+                .term(Term::Other(OtherTerm::Bc), TermForm::default(), false)
+                .unwrap_or(" BC");
+            write_year(date.year, false, &mut s, ad, bc).unwrap();
             s
         } else if let Some(no_date) = ctx
             .ctx(entry, cite_props.clone(), locale, term_locale, false)
@@ -653,6 +660,8 @@ pub fn write_year<W: std::fmt::Write>(
     year: i32,
     short: bool,
     w: &mut W,
+    ad: &str,
+    bc: &str,
 ) -> std::fmt::Result {
     if short && year >= 1000 {
         return write!(w, "{:02}", year % 100);
@@ -664,11 +673,11 @@ pub fn write_year<W: std::fmt::Write>(
         if year > 0 { year } else { year.abs() + 1 },
         if year < 1000 {
             if year <= 0 {
-                "BC"
+                bc
             } else {
                 // AD is used as a postfix, see
                 // https://docs.citationstyles.org/en/stable/specification.html?#ad-and-bc
-                "AD"
+                ad
             }
         } else {
             ""
@@ -2969,7 +2978,7 @@ mod tests {
     fn low_year_test() {
         let yield_year = |year, short| {
             let mut s = String::new();
-            write_year(year, short, &mut s).unwrap();
+            write_year(year, short, &mut s, "AD", "BC").unwrap();
             s
         };
 

--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -810,7 +810,13 @@ fn render_date_part<T: EntryLike>(
                 }
             }
             DateStrongAnyForm::Year(brevity) => {
-                write_year(val, brevity == LongShortForm::Short, ctx).unwrap();
+                let ad = ctx
+                    .term(Term::Other(OtherTerm::Ad), TermForm::default(), false)
+                    .unwrap_or(" AD");
+                let bc = ctx
+                    .term(Term::Other(OtherTerm::Bc), TermForm::default(), false)
+                    .unwrap_or(" BC");
+                write_year(val, brevity == LongShortForm::Short, ctx, ad, bc).unwrap();
             }
         }
     }

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -252,17 +252,17 @@ impl Date {
         ad_prefix: bool,
     ) -> String {
         let np_postfix = match (secular, periods) {
-            (true, false) => " BCE",
-            (true, true) => " B.C.E.",
-            (false, false) => " BC",
-            (false, true) => " B.C.",
+            (true, false) => "BCE",
+            (true, true) => "B.C.E.",
+            (false, false) => "BC",
+            (false, true) => "B.C.",
         };
 
         let positive_dn = match (periods, ad_prefix) {
-            (true, false) => " C.E.",
-            (false, false) => " CE",
-            (true, true) => " A.D.",
-            (false, true) => " AD",
+            (true, false) => "C.E.",
+            (false, false) => "CE",
+            (true, true) => "A.D.",
+            (false, true) => "AD",
         };
 
         if self.year > 0 {

--- a/src/types/time.rs
+++ b/src/types/time.rs
@@ -252,17 +252,17 @@ impl Date {
         ad_prefix: bool,
     ) -> String {
         let np_postfix = match (secular, periods) {
-            (true, false) => "BCE",
-            (true, true) => "B.C.E.",
-            (false, false) => "BC",
-            (false, true) => "B.C.",
+            (true, false) => " BCE",
+            (true, true) => " B.C.E.",
+            (false, false) => " BC",
+            (false, true) => " B.C.",
         };
 
         let positive_dn = match (periods, ad_prefix) {
-            (true, false) => "C.E.",
-            (false, false) => "CE",
-            (true, true) => "AD",
-            (false, true) => "A.D.",
+            (true, false) => " C.E.",
+            (false, false) => " CE",
+            (true, true) => " A.D.",
+            (false, true) => " AD",
         };
 
         if self.year > 0 {

--- a/tests/local/date_DateBCAdjusted.txt
+++ b/tests/local/date_DateBCAdjusted.txt
@@ -6,7 +6,7 @@ citation
 
 
 >>===== RESULT =====>>
-(251BC)
+(251 BC)
 <<===== RESULT =====<<
 
 


### PR DESCRIPTION
Previously it was hard coded to English (without leading spaces).