### PR TITLE
Add `chapter` field

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -146,16 +146,19 @@ impl EntryLike for Entry {
     ) -> Option<MaybeTyped<Cow<'_, Numeric>>> {
         match variable {
             NumberVariable::ChapterNumber => self
-                .bound_select(
-                    &select!(
-                        (("e":Anthos) > ("p":Anthology)) |
-                        (("e":*) > ("p":Reference)) |
-                        (("e":Article) > ("p":Proceedings)) |
-                        (("e":*) > ("p":Book))
-                    ),
-                    "e",
-                )
-                .and_then(Entry::volume)
+                .chapter()
+                .or_else(|| {
+                    self.bound_select(
+                        &select!(
+                            (("e":Anthos) > ("p":Anthology)) |
+                            (("e":*) > ("p":Reference)) |
+                            (("e":Article) > ("p":Proceedings)) |
+                            (("e":*) > ("p":Book))
+                        ),
+                        "e",
+                    )
+                    .and_then(Entry::volume)
+                })
                 .map(MaybeTyped::to_cow),
             NumberVariable::CitationNumber => panic!("processor must resolve this"),
             NumberVariable::CollectionNumber => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub use csl::{
     BibliographyDriver, BibliographyItem, BibliographyRequest, Brackets, BufWriteFormat,
     CitationItem, CitationRequest, CitePurpose, Elem, ElemChild, ElemChildren, ElemMeta,
     Formatted, Formatting, LocatorPayload, Rendered, RenderedBibliography,
-    RenderedCitation, SpecificLocator, TransparentLocator, standalone_citation,
+    RenderedCitation, SpecificLocator, standalone_citation,
 };
 pub use selectors::{Selector, SelectorError};
 
@@ -514,6 +514,13 @@ entry! {
     /// For an item whose parent has multiple issues, indicates the position in
     /// the issue sequence. Also used to indicate the episode number for TV.
     "issue" => issue: MaybeTyped<Numeric>,
+    /// For an item that has chapters, such as book, specifies the number of
+    /// the chapter where this item is located.
+    ///
+    /// This should only be used when the chapter is simply additional
+    /// information; when citing entire chapters, the "chapter" entry type
+    /// should be used instead of this field.
+    "chapter" => chapter: MaybeTyped<Numeric>,
     /// For an item whose parent has multiple volumes/parts/seasons ... of which
     /// this item is one.
     "volume" => volume: MaybeTyped<Numeric>,
@@ -981,7 +988,7 @@ mod tests {
         use io::from_biblatex_str;
 
         let bibtex = r#"
-            @article{b, 
+            @article{b,
                 title={My page ranges},
                 pages={150--es}
             }


### PR DESCRIPTION
This is a follow-up to #361.

We decided to simply remove the automatic conversion of BibTeX book/incollection entry type to chapter for now, as that yields more useful results in general, given the chapter entry type is less supported. Usually, the chapter field is just adjacent information, whereas `@InBook` would be better suited for the `chapter` entry type in CSL (we already perform this conversion).

CSL also has a `chapter-number` field which seems to have the same purpose as the Bib(La)TeX chapter field, which is to simply add extra information about where to find this citation. This PR creates a field for it so we can then map that BibTeX field to it.

However, I'm a bit unsure about adding something like `chapter: 3` for two reasons:
1. This might discourage people from using the chapter entry type altogether. Although it does feel a bit weird on its own.
2. Currently, `entry: chapter` uses `serial-number: 3` to indicate that chapter 3 is being cited. It feels then that `chapter: 3` would have to map to `number` (i.e. function in the same way) for that entry type, as it feels like it's what the user would pick to indicate the chapter being cited.

An alternative is to use `serial-number: { chapter: ... }` which, I guess, would be good enough to discourage users from using it without checking what it does in the docs or something. But it also feels very unnatural.
Paging @reknih for opinions.