### PR TITLE
Fix CLI selector parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,17 +239,15 @@ fn main() {
 
     let bib_len = bibliography.len();
 
-    let selector =
-        matches
-            .get_one("selector")
-            .cloned()
-            .map(|src| match Selector::parse(src) {
-                Ok(selector) => selector,
-                Err(err) => {
-                    eprintln!("Error while parsing selector: {err}");
-                    exit(7);
-                }
-            });
+    let selector = matches.get_one::<String>("selector").cloned().map(|src| {
+        match Selector::parse(&src) {
+            Ok(selector) => selector,
+            Err(err) => {
+                eprintln!("Error while parsing selector: {err}");
+                exit(7);
+            }
+        }
+    });
 
     let bibliography = if let Some(keys) = matches.get_one::<String>("key") {
         let mut res = vec![];


### PR DESCRIPTION
Clap stores argument values as owned Strings. Attempting to downcast via `matches.get_one(...)` without the concrete type caused a runtime downcast panic when the code inferred. Request the stored type explicitly with `get_one::<String>()` and pass its `&str` to `Selector::parse`.

This fixes a crash when running the CLI with a selector argument.

### Before
```sh
thread 'main' panicked at src/main.rs:244:14:
Mismatch between definition and access of `selector`. Could not downcast to &str, need to downcast to alloc::string::String

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### After
```sh
[1]
Mädje, Laurenz, Haug, Martin, un Typst Projekta Izstrādātāji, "Typst". Skatīts: 2025. gada1.janvārī. [Tiešsaiste]. Pieejams: https://typst.app/
```