### PR TITLE
Expose `TransparentLocator` again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub use csl::{
     BibliographyDriver, BibliographyItem, BibliographyRequest, Brackets, BufWriteFormat,
     CitationItem, CitationRequest, CitePurpose, Elem, ElemChild, ElemChildren, ElemMeta,
     Formatted, Formatting, LocatorPayload, Rendered, RenderedBibliography,
-    RenderedCitation, SpecificLocator, standalone_citation,
+    RenderedCitation, SpecificLocator, TransparentLocator, standalone_citation,
 };
 pub use selectors::{Selector, SelectorError};
 


### PR DESCRIPTION
Undo accidental regression from #383 that removed TransparentLocator from public exports (after #299).

Reported by @SillyFreak at https://github.com/typst/hayagriva/pull/383#issuecomment-3335993578 (thank you very much!).