### PR TITLE
Fix wrong ibid position, test transparent locators

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -2239,7 +2239,8 @@ impl DisambiguateState {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IbidState {
-    /// The previous cite referenced another entry.
+    /// The previous cite referenced another entry, or this cite has no locator
+    /// when the previous one did.
     Different,
     /// The previous cite referenced the same entry, but with a different
     /// locator.

--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -3127,6 +3127,12 @@ mod tests {
                 author: "Surname, Name"
                 location: Warsaw
                 date: 1971
+            katalog2:
+                type: Book
+                title: "Book2"
+                author: "Surname, Name"
+                location: Warsaw
+                date: 1971
         "#;
         let test_style = r#"<?xml version="1.0" encoding="utf-8"?>
         <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
@@ -3175,16 +3181,19 @@ mod tests {
         let citationberg::Style::Independent(style) = style else { unreachable!() };
 
         let mut driver = BibliographyDriver::new();
-        let entry = library.get("katalog").unwrap();
-        let supplements = [
-            (Some([2, 3]), "first."),
-            (Some([2, 3]), "ibid."),
-            (Some([2, 3]), "ibid."),
-            (Some([2, 4]), "ibid-with-locator."),
-            (None, "subsequent."),
+        let citations = [
+            ("katalog", Some([2, 3]), "first."),
+            ("katalog", Some([2, 3]), "ibid."),
+            ("katalog", Some([2, 3]), "ibid."),
+            ("katalog", Some([2, 4]), "ibid-with-locator."),
+            ("katalog", None, "subsequent."),
+            ("katalog", Some([2, 3]), "ibid-with-locator."),
+            ("katalog", Some([2, 3]), "ibid."),
+            ("katalog2", Some([2, 3]), "first."),
         ];
 
-        for (supplement, _) in supplements {
+        for (entry, supplement, _) in citations {
+            let entry = library.get(entry).unwrap();
             driver.citation(CitationRequest::new(
                 vec![CitationItem::with_locator(
                     entry,
@@ -3208,7 +3217,7 @@ mod tests {
             locale_files: &[],
         });
 
-        for (citation, (_, expected_value)) in finished.citations.iter().zip(supplements)
+        for (citation, (_, _, expected_value)) in finished.citations.iter().zip(citations)
         {
             let mut s = String::new();
             citation.citation.write_buf(&mut s, BufWriteFormat::Plain).unwrap();

--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -2257,7 +2257,14 @@ impl IbidState {
             if last.entry == this.entry && !last.hidden {
                 if last.locator == this.locator {
                     IbidState::Ibid
+                } else if this.locator.is_none() {
+                    // Per CSL spec: "Preceding cite does have a locator: (...)
+                    // If the current cite lacks a locator its only position is
+                    // 'subsequent'."
+                    IbidState::Different
                 } else {
+                    // - Both have locators, but they differ
+                    // - Previous one has no locator, this one does
                     IbidState::IbidWithLocator
                 }
             } else {


### PR DESCRIPTION
According to the CSL spec[^1] (emphasis mine):

> The presence of locators determines which position is assigned:
> 
>  - Preceding cite does not have a locator: if the current cite has a locator, the position of the current cite is “ibid-with-locator”. Otherwise the position is “ibid”.
>  - Preceding cite does have a locator: if the current cite has the same locator, the position of the current cite is “ibid”. If the locator differs the position is “ibid-with-locator”. **If the current cite lacks a locator its only position is “subsequent”.**

Prior logic only checked if the locators differed in any way, assigning "ibid with locator" if so. But that included differing by the previous citation having a locator and the current one not having one, whereas that case should be handled differently per the spec, and the position should be subsequent instead.
(Related: #301, though that fixed a different bug.)

Added tests for transparent locators, which not only verify this behavior has been fixed but also properly test the additions in #299.

[^1]: https://docs.citationstyles.org/en/stable/specification.html#choose