### PR TITLE
Don't count year-suffix as a variable access

### DIFF
--- a/src/csl/rendering/mod.rs
+++ b/src/csl/rendering/mod.rs
@@ -169,7 +169,15 @@ impl RenderCsl for citationberg::Text {
         if suppressing {
             ctx.writing.start_suppressing_queried_variables();
         }
-        let targets_variable = matches!(self.target, TextTarget::Variable { .. });
+        let targets_variable = match self.target {
+            // Year suffix is not counted as a variable
+            TextTarget::Variable {
+                var: Variable::Standard(StandardVariable::YearSuffix),
+                ..
+            } => false,
+            TextTarget::Variable { .. } => true,
+            _ => false,
+        };
 
         let Some(target) = lookup_result else {
             return (
@@ -209,6 +217,7 @@ impl RenderCsl for citationberg::Text {
     }
 }
 
+#[derive(Debug)]
 enum ResolvedTextTarget<'a, 'b> {
     StandardVariable(StandardVariable, Cow<'a, ChunkedString>),
     NumberVariable(NumberVariable, NumberVariableResult<'a>),

--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -173,6 +173,7 @@ form_TitleTestNoLongFalse
 fullstyles_ABdNT
 fullstyles_APA
 fullstyles_ChicagoNoteWithBibliographyWithPublisher
+group_ComplexNesting
 group_ShortOutputOnly
 group_SuppressValueWithEmptySubgroup
 group_SuppressWithEmptyNestedDateNode

--- a/tests/citeproc.rs
+++ b/tests/citeproc.rs
@@ -434,7 +434,7 @@ impl TestSuiteResults {
 #[ignore]
 fn test_single_file() {
     let locales = locales();
-    let name = "bugreports_ArabicLocale.txt";
+    let name = "date_YearSuffixImplicitWithNoDate.txt";
     let test_path = PathBuf::from(CACHE_PATH)
         .join(TEST_REPO_NAME)
         .join("processor-tests/humans/");
@@ -947,7 +947,7 @@ fn access_date() {
         .content
         .write_buf(&mut buf, hayagriva::BufWriteFormat::Plain)
         .unwrap();
-    assert_eq!(buf, "Retrieved 2021, from https://example.com/");
+    assert_eq!(buf, "(n.d.). Retrieved 2021, from https://example.com/");
 }
 
 #[test]


### PR DESCRIPTION
Adds group_ComplexNesting to citeproc-pass. Closes #392.