### PR TITLE
Improve CSL test parsing

### DIFF
--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -136,6 +136,7 @@ date_SeasonSubstituteInGroup
 date_SortEmptyDatesBibliography
 date_SortEmptyDatesCitation
 date_YearSuffixDelimiter
+date_YearSuffixImplicitWithNoDateOneOnly
 decorations_SimpleQuotes
 disambiguate_AddNamesSuccess
 disambiguate_AllNamesWithInitialsBibliography
@@ -385,6 +386,7 @@ number_SimpleNumberArabic
 number_SimpleNumberOrdinalLong
 number_SimpleNumberOrdinalShort
 number_SimpleNumberRoman
+number_SpacesMakeIsNumericFalse
 number_StrangeError
 page_Chicago
 page_Chicago16

--- a/tests/citeproc.rs
+++ b/tests/citeproc.rs
@@ -389,15 +389,10 @@ impl TestSuiteResults {
 
         for path in iter_files_with_name(&test_path, "txt", |name| {
             ![
-                "affix_PrefixWithDecorations",
                 "flipflop_ApostropheInsideTag",
-                "date_OtherAlone",
                 // Upstream bug: https://github.com/tafia/quick-xml/issues/674
                 "bugreports_SelfLink",
                 "bugreports_SingleQuoteXml",
-                "number_SpacesMakeIsNumericFalse",
-                "textcase_LocaleUnicode",
-                "date_YearSuffixImplicitWithNoDateOneOnly",
                 "position_NearNoteWithPlugin",
             ]
             .contains(&name)


### PR DESCRIPTION
The CSL test fixtures are not formatted as well as Hayagriva assumed. I relaxed the requirements a lot and now the only parsing errors are due to JSON errors (because some tests contain an empty object for some reason) and XML errors due to tafia/quick-xml#674.

7 additional tests are added; 2 of them pass; 3 are skipped:
- bugreports_EnvAndUrb: Skipped, uses `CITATIONS`
- affix_PrefixFullCitationTextOnly: Skipped, uses prefix
- affix_PrefixWithDecorations: Skipped, uses prefix
- date_OtherAlone: Fails, uses literal date
- number_SpacesMakeIsNumericFalse: Passes
- textcase_LocaleUnicode: Fails, we don't give the same error message
- date_YearSuffixImplicitWithNoDateOneOnly: Passes 