### PR TITLE
recognize Anthos as Chapter in CSL

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -605,9 +605,10 @@ impl EntryLike for Entry {
 
                 !(is_periodical || is_collection)
             }
-            Kind::Chapter => {
-                select!(Chapter > (Book | Anthology | Proceedings)).matches(self)
-            }
+            Kind::Chapter => select!(
+                (Anthos > Anthology) | (Chapter > (Book | Anthology | Proceedings))
+            )
+            .matches(self),
             Kind::Entry | Kind::EntryDictionary | Kind::EntryEncyclopedia => {
                 if kind == Kind::EntryDictionary {
                     // TODO: We do not differentiate between dictionaries and other


### PR DESCRIPTION
As discussed in #148 a biblatex entry of type `@incollection` is recognized as hayagriva type `Anthos` of an `Anthology`.

#72 (PR #74) claims that `Anthos` is recognized as being a CSL type `chapter`. However https://github.com/typst/hayagriva/issues/148#issuecomment-3064023480 produced a CSL style for debugging this issue which shows, that `@incollection` sources are not recognized as `chapter`s. 

https://github.com/ashprice/hayagriva/commit/49d88b2d37d1e9b72e115bd675ccaaf87bee4101 proposes a solution for this problem, however i could not find a final resolution/verdict or a related PR.

Since I am affected by this problem and it appears to persist I want to propose my solution with a slightly more strict matcher than proposed by https://github.com/ashprice/hayagriva/commit/49d88b2d37d1e9b72e115bd675ccaaf87bee4101.

I hope I did not miss a verdict somewhere else and am open to further opinions on this matter since I am neither an expert in Rust nor in the semantics of citation source types.