### PR TITLE
Fix error span pointing to wrong entry when type is missing (#441)

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -103,4 +103,56 @@ mod tests {
             assert_eq!(match_e, &entry);
         }
     }
+
+    fn assert_error_location(err: &serde_yaml::Error, line: usize, column: usize) {
+        let location = err
+            .location()
+            .unwrap_or_else(|| panic!("Expected error location. Got: {err}"));
+        assert_eq!(
+            (location.line(), location.column()),
+            (line, column),
+            "Error location mismatch. Got: {}:{}",
+            location.line(),
+            location.column()
+        );
+    }
+
+    #[test]
+    fn issue_441() {
+        // Exact scenario from GitHub issue #441
+        let yaml = r#"a:
+  type: article
+
+b:
+  title: "Bee movie"
+"#;
+        let err = from_yaml_str(yaml).unwrap_err();
+
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("`b`"),
+            "Error should identify entry 'b'. Got: {err_str}",
+        );
+        assert_error_location(&err, 5, 3);
+    }
+
+    #[test]
+    fn missing_type_first() {
+        // Edge case: the first entry is missing its type
+        let yaml = r#"first-entry:
+  title: "Missing type"
+
+second-entry:
+  type: article
+  title: "This one is fine"
+"#;
+        let err = from_yaml_str(yaml).unwrap_err();
+
+        let err_str = err.to_string();
+        assert!(
+            err_str.contains("first-entry"),
+            "Error should identify 'first-entry'. Got: {err_str}",
+        );
+        assert_error_location(&err, 2, 3);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ macro_rules! entry {
                     {
                         let entry_type = self.entry_type
                             .or_else(|| child_entry_type.map(|e| e.default_parent()))
-                            .ok_or_else(|| E::custom("no entry type"))?;
+                            .ok_or_else(|| E::custom(format!("no entry type for `{}`", key)))?;
 
                         let parents: Result<Vec<_>, _> = self.parents
                             .into_iter()
@@ -415,7 +415,47 @@ macro_rules! entry {
                     where
                         A: serde::de::MapAccess<'de>,
                     {
-                        let mut entries = Vec::with_capacity(
+                        struct EntrySeed<'a> {
+                            key: &'a str,
+                        }
+
+                        impl<'de, 'a> serde::de::DeserializeSeed<'de> for EntrySeed<'a> {
+                            type Value = Entry;
+
+                            fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                            where
+                                D: serde::de::Deserializer<'de>,
+                            {
+                                struct EntryVisitor<'a> {
+                                    key: &'a str,
+                                }
+
+                                impl<'de, 'a> Visitor<'de> for EntryVisitor<'a> {
+                                    type Value = Entry;
+
+                                    fn expecting(
+                                        &self,
+                                        formatter: &mut std::fmt::Formatter,
+                                    ) -> std::fmt::Result {
+                                        formatter.write_str("a map representing a bibliography entry")
+                                    }
+
+                                    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+                                    where
+                                        A: serde::de::MapAccess<'de>,
+                                    {
+                                        let deserializer =
+                                            serde::de::value::MapAccessDeserializer::new(map);
+                                        let naked_entry = NakedEntry::deserialize(deserializer)?;
+                                        naked_entry.into_entry(self.key, None)
+                                    }
+                                }
+
+                                deserializer.deserialize_map(EntryVisitor { key: self.key })
+                            }
+                        }
+
+                        let mut entries: Vec<(String, Entry)> = Vec::with_capacity(
                             map.size_hint().unwrap_or(0).min(128)
                         );
                         while let Some(key) = map.next_key::<String>()? {
@@ -426,16 +466,12 @@ macro_rules! entry {
                                 )));
                             }
 
-                            let entry: NakedEntry = map.next_value()?;
+                            // Convert immediately so errors report the correct position
+                            let entry = map.next_value_seed(EntrySeed { key: &key })?;
                             entries.push((key, entry));
                         }
 
-                        let entries: Result<IndexMap<_, _>, A::Error> =
-                            entries.into_iter().map(|(k, v)| {
-                                v.into_entry(&k, None).map(|e| (k, e))
-                            }).collect();
-
-                        Ok(Library(entries?))
+                        Ok(Library(entries.into_iter().collect()))
                     }
                 }
 


### PR DESCRIPTION
Fixes #441

When an entry was missing its `type`, the error span would point to the first entry in the bibliography instead of the actual problematic entry. This made debugging large bibliographies difficult.

Root cause: entries were first collected as `NakedEntry` structs, then converted to `Entry` in a second pass. By that point, serde had already moved past the original position.

Solution: use `DeserializeSeed` to convert each entry immediately during deserialization, preserving correct error locations. The error message now also includes the entry key for clarity ("no entry type for `key`").