### PR TITLE
[Feature] Pass Directors For Unparented Video and Audio

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -453,7 +453,7 @@ impl EntryLike for Entry {
             NameVariable::Director => self
                 .bound_select(
                     &select!(
-                        (* > ("p":(Audio | Video)))
+                        (* > ("p":(Audio | Video))) | ("p":(Audio | Video))
                     ),
                     "p",
                 )


### PR DESCRIPTION
Currently entries require a video/audio parent to pass the Director affiliated role.
This simple change brings `Director` in line with `SeriesCreator`, allowing unparented video/audio entries to show director attribution on their own.

*Please let me know if this is on purpose / works as intended.*