### PR TITLE
Fix prose citations using "&" instead of "and" between author names

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -1377,7 +1377,9 @@ impl<'a> StyleContext<'a> {
                 }
             }
             (Some(CitePurpose::Prose), _) => {
+                ctx.writing.use_text_and = true;
                 do_author(&mut ctx);
+                ctx.writing.use_text_and = false;
                 if !self
                     .csl
                     .citation
@@ -1735,6 +1737,8 @@ pub(crate) struct WritingContext {
     /// Delimiters from ancestor delimiting elements (e.g., `cs:group`).
     /// To be applied within `cs:choose`, but not another delimiting element or a macro.
     delimiters: NonEmptyStack<Option<String>>,
+    /// Use "and" instead of "&" when joining names, for prose citations.
+    use_text_and: bool,
 
     // Buffers.
     /// The buffer we're writing to. If block-level or formatting changes, we
@@ -1760,6 +1764,7 @@ impl Default for WritingContext {
             cases: NonEmptyStack::default(),
             name_options: NonEmptyStack::default(),
             delimiters: NonEmptyStack::default(),
+            use_text_and: false,
             buf: CaseFolder::default(),
             elem_stack: NonEmptyStack::default(),
         }
@@ -3347,7 +3352,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(c1, "Downs (1957)");
-        assert_eq!(c2, "Brady & Collier (2010)");
+        assert_eq!(c2, "Brady and Collier (2010)");
     }
     #[test]
     #[cfg(feature = "archive")]

--- a/src/csl/rendering/names.rs
+++ b/src/csl/rendering/names.rs
@@ -542,6 +542,10 @@ fn add_names<T: EntryLike>(
                         NameAnd::Text => ctx
                             .term(Term::Other(OtherTerm::And), TermForm::default(), false)
                             .unwrap_or_default(),
+                        // Prose citations use "and" instead of "&".
+                        NameAnd::Symbol if ctx.writing.use_text_and => ctx
+                            .term(Term::Other(OtherTerm::And), TermForm::default(), false)
+                            .unwrap_or("and"),
                         NameAnd::Symbol => "&",
                     });
                     ctx.ensure_space();
@@ -552,6 +556,9 @@ fn add_names<T: EntryLike>(
                         NameAnd::Text => ctx
                             .term(Term::Other(OtherTerm::And), TermForm::default(), false)
                             .unwrap_or_default(),
+                        NameAnd::Symbol if ctx.writing.use_text_and => ctx
+                            .term(Term::Other(OtherTerm::And), TermForm::default(), false)
+                            .unwrap_or("and"),
                         NameAnd::Symbol => "&",
                     });
                     ctx.ensure_space();


### PR DESCRIPTION
  - Prose citations (form: "prose") currently use "&" to join author names, but should use "and". This affects any CSL style with and="symbol" (e.g. APA).
  - Adds a use_text_and flag to WritingContext, set during prose author rendering, which causes the name joiner to use the localized "and" term instead of "&"
  - Updates the existing issue_243 test to expect "and"

The approach works and matches the existing pattern of toggling context flags in WritingContext, though it's admittedly a bit of a bolted-on solution. Open to suggestions on a cleaner approach.

Closes #454