### PR TITLE
Fix name suffix example in documentation

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -452,7 +452,7 @@ journal:
 
 #### Person
 
-A person consists of a name and optionally, a given name, a prefix, and a suffix for the (family) name as well as an alias. Usually, you specify a person as a string with the prefix and the last name first, then a comma, followed by a given name, another comma, and then finally the suffix. Following items are valid persons:
+A person consists of a name and optionally, a given name, a prefix, and a suffix for the (family) name as well as an alias. Usually, you specify a person as a string with the prefix and the last name first, then a comma, optionally followed by a suffix, another comma, and then finally the given name. Following items are valid persons:
 
 - `Doe, Janet`
 - `Luther King, Jr., Martin`

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -455,7 +455,7 @@ journal:
 A person consists of a name and optionally, a given name, a prefix, and a suffix for the (family) name as well as an alias. Usually, you specify a person as a string with the prefix and the last name first, then a comma, followed by a given name, another comma, and then finally the suffix. Following items are valid persons:
 
 - `Doe, Janet`
-- `Luther King, Martin, Jr.`
+- `Luther King, Jr., Martin`
 - `UNICEF`
 - `von der Leyen, Ursula`
 


### PR DESCRIPTION
[The documentation for the person data type](https://github.com/typst/hayagriva/blob/main/docs/file-format.md#Person) shows an incorrect example of a name with a suffix - `Luther King, Martin, Jr.` instead of the correct `Luther King, Jr., Martin`.

This pull request changes this example to the correct name order.

Closes #451 