### PR TITLE
Add aliases for `modern-language-association-8` and `mla-8`

### DIFF
--- a/src/csl/archive.rs
+++ b/src/csl/archive.rs
@@ -398,6 +398,8 @@ impl ArchivedStyle {
             "modern-humanities-research-association" => Some(Self::ModernHumanitiesResearchAssociationNotes),
             "modern-language-association" => Some(Self::ModernLanguageAssociation),
             "mla" => Some(Self::ModernLanguageAssociation),
+            "modern-language-association-8" => Some(Self::ModernLanguageAssociation),
+            "mla-8" => Some(Self::ModernLanguageAssociation),
             "multidisciplinary-digital-publishing-institute" => Some(Self::MultidisciplinaryDigitalPublishingInstitute),
             "nature" => Some(Self::Nature),
             "nlm-citation-sequence" => Some(Self::NlmCitationSequence),
@@ -867,6 +869,8 @@ impl ArchivedStyle {
             Self::ModernLanguageAssociation => &[
                 "modern-language-association",
                 "mla",
+                "modern-language-association-8",
+                "mla-8",
             ],
             Self::MultidisciplinaryDigitalPublishingInstitute => &[
                 "multidisciplinary-digital-publishing-institute",

--- a/tests/archiver.rs
+++ b/tests/archiver.rs
@@ -665,7 +665,7 @@ const OVERRIDES: [Override; 23] = [
     Override::alias(
         "modern-language-association",
         "modern-language-association",
-        &["mla"],
+        &["mla", "modern-language-association-8", "mla-8"],
     ),
     Override::alias("plos", "public-library-of-science", &["plos"]),
     Override::first("thieme-german", "thieme"),


### PR DESCRIPTION
Regarding https://github.com/typst/hayagriva/pull/453#issuecomment-4543041746.

Just discussed with @reknih and given that the differences are supposedly minor and the mapping is in [`renamed-styles.json`](https://github.com/adunning/styles/blob/b6bdd86b2336884c4236857481a0006817bccc21/renamed-styles.json), we decided to add the alias after all to avoid breakage.

Typst will emit a deprecation warning for these styles.