### PR TITLE
Add citeproc tests that failed because of `<b> </b>`

### DIFF
--- a/tests/citeproc-pass.txt
+++ b/tests/citeproc-pass.txt
@@ -487,6 +487,9 @@ sort_NumberOfAuthorsAsKey
 sort_StatusFieldAscending
 sort_StatusFieldDescending
 sort_TestInheritance
+sort_VariousNameMacros1
+sort_VariousNameMacros2
+sort_VariousNameMacros3
 sortseparator_SortSeparatorEmpty
 substitute_RepeatedNamesOk
 substitute_SubstituteOnlyOnceString

--- a/tests/citeproc.rs
+++ b/tests/citeproc.rs
@@ -746,7 +746,15 @@ mod citeproc_bib {
 
         match formatting.font_weight {
             FontWeight::Bold => {
-                push_elem("<b>", "</b>");
+                // Make regular texts bold, but keep whitespaces unformatted.
+                //
+                // A CSL style may set `font-weight="bold"` on `<group>` with
+                // whitespace affixes. It does not matter whether such affixes
+                // are bold or regular. Citeproc tests prefer regular at present.
+                // (cf. test sort_VariousNameMacros1.txt)
+                if text.text.chars().any(|c| !c.is_whitespace()) {
+                    push_elem("<b>", "</b>");
+                }
             }
             FontWeight::Light => {
                 // NOTE: This is not used in any tests, so we can only assume


### PR DESCRIPTION
These three citeproc tests actually pass, but there were thought as failed because hayagriva writes ` ` (whitespace) as `<b> </b>`.
This PR adds them to `citeproc-pass.txt`.

[`name_InTextMarkupInitialize`](https://github.com/citation-style-language/test-suite/tree/master/processor-tests/humans/name_InTextMarkupInitialize.txt) and [`name_InTextMarkupNormalizeInitials`](https://github.com/citation-style-language/test-suite/tree/master/processor-tests/humans/name_InTextMarkupNormalizeInitials.txt) have a similar problem.
They provide the author name as `{ "given": "<b>John</b>-Quiggly" }`, and hayagriva generates `<b>J. Q.` instead of the expected `<b>J.</b> Q.`.
However, that's more difficult to circumvent, and they are the only two test cases whose names contain _InTextMarkUp_.
Therefore, I don't they worth special handling.

(By the way, I found them with https://ydx-2147483647.github.io/haya-view-test/.)
