### PR TITLE
Changed associated type `Err` for `FromStr` implementation for `MaybeTyped<T>`

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::convert::Infallible;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
@@ -369,7 +370,7 @@ impl<T> FromStr for MaybeTyped<T>
 where
     T: FromStr,
 {
-    type Err = ();
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self::infallible_from_str(s))


### PR DESCRIPTION
I'm using Hayagriva as a library, and ran into trait bound troubles because the compiler expected an `Error` implementation for the associated type `Err` for the implementation of `FromStr` for `MaybeTyped<T>`.

I noticed that `Err` is currently set as the unit type, which also suggests that parsing can fail in exactly one way. However, parsing cannot fail at all for `MaybeTyped<T>`, so it seems to make more sense that `Err` would be [`Infallible`](https://doc.rust-lang.org/std/convert/enum.Infallible.html), the error type intended for this situation.