### PR TITLE
Fallback to `Entry::organization` for CSL `publisher`

### DIFF
--- a/src/csl/taxonomy.rs
+++ b/src/csl/taxonomy.rs
@@ -265,6 +265,8 @@ impl EntryLike for Entry {
             }
             StandardVariable::ArchivePlace => None,
             StandardVariable::Authority => {
+                // `Entry::organization` may also appear as `StandardVariable::Publisher`.
+                // See the comment in that arm.
                 entry.organization().map(|f| f.select(form)).map(Cow::Borrowed)
             }
             StandardVariable::CallNumber => {
@@ -354,6 +356,20 @@ impl EntryLike for Entry {
             StandardVariable::Publisher => entry
                 .map(|e| e.publisher())
                 .and_then(Publisher::name)
+                // Fallback to `organization` if `publisher` is missing.
+                //
+                // Many CSL styles use `<text variable="publisher"/>` to display
+                // the university where a thesis was written, because Zotero
+                // exports the university to `publisher` in CSL-JSON.
+                //
+                // However, Zotero exports university to `institution` in BibLaTeX.
+                // In BibLaTeX, `publisher` and `institution` are separate fields
+                // (`school` is an alias for `institution`). We map them to
+                // `Entry::publisher` and `Entry::organization` respectively.
+                //
+                // Therefore, this fallback is necessary to make BibLaTeX data
+                // usable for such CSL styles.
+                .or_else(|| entry.organization())
                 .map(|n| n.select(form))
                 .map(Cow::Borrowed),
             StandardVariable::PublisherPlace => entry
@@ -936,4 +952,59 @@ fn letter(val: u8) -> String {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::from_biblatex_str;
+
+    #[test]
+    fn zotero_university_interop() {
+        let entry = from_biblatex_str(
+        r#"
+        @thesis{zotero-export-better-biblatex,
+            type = {Unpublished master’s thesis},
+            title = {Fathers’ Participation in Family Work: {{Consequences}} for Fathers’ Stress and Father-Child Relations},
+            author = {Almeida, David M.},
+            namea = {Galambos, Nancy L.},
+            nameatype = {collaborator},
+            date = {1990-11},
+            institution = {University of Victoria},
+            location = {Victoria, British Columbia, Canada},
+            langid = {american}
+        }
+        "#,
+    ).unwrap().into_iter().next().unwrap();
+        assert_eq!(entry.publisher().unwrap().name(), None);
+        assert_eq!(
+            entry.publisher().unwrap().location().unwrap(),
+            &"Victoria, British Columbia, Canada".parse().unwrap()
+        );
+        assert_eq!(
+            entry.organization().unwrap(),
+            &"University of Victoria".parse().unwrap()
+        );
+
+        assert_eq!(
+            entry
+                .resolve_standard_variable(
+                    Default::default(),
+                    StandardVariable::Publisher
+                )
+                .unwrap()
+                .to_str(),
+            "University of Victoria"
+        );
+        assert_eq!(
+            entry
+                .resolve_standard_variable(
+                    Default::default(),
+                    StandardVariable::PublisherPlace
+                )
+                .unwrap()
+                .to_str(),
+            "Victoria, British Columbia, Canada"
+        );
+    }
 }


### PR DESCRIPTION
- Resolves #112.
- The institution part in #265 is the same as the above.
- The school part in typst/biblatex#68 is also the same.

This PR improves the interoperability with Zotero and BibLaTeX.

Many CSL styles use `<text variable="publisher"/>` to display the university where a thesis was written, because Zotero exports the university to `publisher` in CSL-JSON.
However, Zotero exports university to `institution` in BibLaTeX. In BibLaTeX, `publisher` and `institution` are separate fields (`school` is an alias for `institution`). Hayagriva maps them to `publisher` and `organization` respectively, which are further mapped to the CSL variables `publisher` and `authority` respectively.
Therefore, `institution` in BibLaTeX gets lost when using with such CSL styles.

(Relevant specifications of Bib(La)TeX, Hayagriva, and CSL can be found at https://github.com/typst/hayagriva/issues/112#issuecomment-4608384090.)

To fix it, this PR makes CSL `publisher` fallback to Hayagriva `organization` if `publisher` is missing.

```mermaid
flowchart LR

subgraph Zotero[Zotero UI]
    university["University<br>(for theses)"]
    publisher["Publisher<br>(for books etc.)"]
end
subgraph BibTeX
    bibtex.institution["institution<br>(for reports)"]
    bibtex.school["school<br>(for theses)"]
    bibtex.publisher[publisher]
end
subgraph BibLaTeX
    biblatex.publisher[publisher]
    biblatex.institution["institution<br>(school becomes an alias)"]
end
subgraph Hayagriva
    haya.publisher[publisher]
    haya.organization[organization]
end
subgraph CSL
    csl.publisher[publisher]
    csl.authority[authority]
end

bibtex.institution --- biblatex.institution
bibtex.school --- biblatex.institution
bibtex.publisher --- biblatex.publisher

biblatex.publisher --> haya.publisher
biblatex.institution --> haya.organization

haya.publisher --> csl.publisher
haya.organization --> csl.authority
haya.organization -.->|"Fallback<br>added by this PR"| csl.publisher

university -.->|Export to<br>Better BibTeX| bibtex.school
university -.->|Export to<br>Better BibLaTeX| biblatex.institution
university -.->|Export to CSL-JSON| csl.publisher

publisher -.->|Export to<br>Better BibTeX| bibtex.publisher
publisher -.->|Export to<br>Better BibLaTeX| biblatex.publisher
publisher -.->|Export to CSL-JSON| csl.publisher

classDef important fill:lightgreen
class university,bibtex.school,biblatex.institution,csl.publisher important
classDef wrong fill:lightblue
class publisher,bibtex.publisher,biblatex.publisher wrong
```

## Alternative solution

https://github.com/typst/hayagriva/issues/265#issuecomment-3693840831 proposed an alternative solution: remap BibLaTeX `publisher` to Hayagriva `archive` and BibLaTeX `institution` to Hayagriva `publisher`.

I believe this solution will cause more confusion, because it changes _Publisher_ in Zotero UI from CSL `publisher` to CSL `archive`.

```mermaid
flowchart LR

subgraph Zotero[Zotero UI]
    university["University<br>(for theses)"]
    publisher["Publisher<br>(for books etc.)"]
end
subgraph BibTeX
    bibtex.institution["institution<br>(for reports)"]
    bibtex.school["school<br>(for theses)"]
    bibtex.publisher[publisher]
end
subgraph BibLaTeX
    biblatex.publisher[publisher]
    biblatex.institution["institution<br>(school becomes an alias)"]
end
subgraph Hayagriva
    haya.publisher[publisher]
    haya.organization[organization]
    haya.archive[archive]
end
subgraph CSL
    csl.publisher[publisher]
    csl.authority[authority]
    csl.archive[archive]
end

bibtex.institution --- biblatex.institution
bibtex.school --- biblatex.institution
bibtex.publisher --- biblatex.publisher

biblatex.institution -->|"🔀 Remap"| haya.publisher
biblatex.publisher -->|"🔀 Remap"| haya.archive

haya.organization --> csl.authority
haya.archive --> csl.archive
haya.publisher --> csl.publisher

university -.->|Export to<br>Better BibTeX| bibtex.school
university -.->|Export to<br>Better BibLaTeX| biblatex.institution
university -.->|Export to CSL-JSON| csl.publisher

publisher -.->|Export to<br>Better BibTeX| bibtex.publisher
publisher -.->|Export to<br>Better BibLaTeX| biblatex.publisher
publisher -.->|Export to CSL-JSON| csl.publisher

classDef important fill:lightgreen
class university,bibtex.school,biblatex.institution,csl.publisher important
classDef wrong fill:lightblue
class publisher,bibtex.publisher,biblatex.publisher wrong
style csl.archive fill:red
```
