### PR TITLE
Fix citation number offsetting for sorted bibliographies

### DIFF
--- a/src/csl/mod.rs
+++ b/src/csl/mod.rs
@@ -133,7 +133,8 @@ impl<T: EntryLike + Hash + PartialEq + Eq + Debug> BibliographyDriver<'_, T> {
             |_| 0,
         );
         let citation_number = |item: &T| {
-            entries.iter().position(|e| e.entry == item).expect("entry not found")
+            self.citation_number_offset
+                + entries.iter().position(|e| e.entry == item).expect("entry not found")
         };
 
         let mut seen: HashSet<*const T> = HashSet::new();


### PR DESCRIPTION
https://github.com/typst/hayagriva/pull/409 only handled citation number offsetting for styles without sorting. This PR extends it to sorted styles.