### PR TITLE
Add ability to declare locator type to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -139,6 +140,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ unscanny = "0.1.0"
 url = { version = "2.4", features = ["serde"] }
 biblatex = { version = "0.12.0", features = ["unic-langid"], optional = true }
 ciborium = { version = "0.2.1", optional = true }
-clap = { version = "4", optional = true, features = ["cargo"] }
+clap = { version = "4", optional = true, features = ["cargo", "derive"] }
 strum = { version = "0.26", features = ["derive"], optional = true }
 icu_collator = "2.2.0"
 icu_locale = "2.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ enum LocatorTypes {
     Canon,
     Chapter,
     Column,
-    #[value(name="e-location")]
+    #[value(name = "e-location")]
     Elocation,
     Equation,
     Figure,
@@ -460,9 +460,13 @@ verse       volume"#)
             let (style, locales, locale) =
                 retrieve_assets(style, csl, locale_path, locale_str);
 
-            let indicated_locator = if let Some(locator_type) = sub_matches.get_one::<LocatorTypes>("locator_type") {
+            let indicated_locator = if let Some(locator_type) =
+                sub_matches.get_one::<LocatorTypes>("locator_type")
+            {
                 locator_type.into()
-            } else { Locator::Custom };
+            } else {
+                Locator::Custom
+            };
 
             let assign_locator = |(i, e)| {
                 let mut item = CitationItem::with_entry(e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,76 @@ impl ValueEnum for Format {
     }
 }
 
+#[derive(ValueEnum, Clone)]
+enum LocatorTypes {
+    Act,
+    Appendix,
+    ArticleLocator,
+    Book,
+    Canon,
+    Chapter,
+    Column,
+    #[value(name="e-location")]
+    Elocation,
+    Equation,
+    Figure,
+    Folio,
+    Issue,
+    Line,
+    Note,
+    Opus,
+    Page,
+    Paragraph,
+    Part,
+    Rule,
+    Scene,
+    Section,
+    SubVerbo,
+    Supplement,
+    Table,
+    Timestamp,
+    Title,
+    TitleLocator,
+    Verse,
+    Volume,
+}
+
+impl From<&LocatorTypes> for Locator {
+    fn from(value: &LocatorTypes) -> Self {
+        match value {
+            LocatorTypes::Act => Locator::Act,
+            LocatorTypes::Appendix => Locator::Appendix,
+            LocatorTypes::ArticleLocator => Locator::ArticleLocator,
+            LocatorTypes::Book => Locator::Book,
+            LocatorTypes::Canon => Locator::Canon,
+            LocatorTypes::Chapter => Locator::Chapter,
+            LocatorTypes::Column => Locator::Column,
+            LocatorTypes::Elocation => Locator::Elocation,
+            LocatorTypes::Equation => Locator::Equation,
+            LocatorTypes::Figure => Locator::Figure,
+            LocatorTypes::Folio => Locator::Folio,
+            LocatorTypes::Issue => Locator::Issue,
+            LocatorTypes::Line => Locator::Line,
+            LocatorTypes::Note => Locator::Note,
+            LocatorTypes::Opus => Locator::Opus,
+            LocatorTypes::Page => Locator::Page,
+            LocatorTypes::Paragraph => Locator::Paragraph,
+            LocatorTypes::Part => Locator::Part,
+            LocatorTypes::Rule => Locator::Rule,
+            LocatorTypes::Scene => Locator::Scene,
+            LocatorTypes::Section => Locator::Section,
+            LocatorTypes::SubVerbo => Locator::SubVerbo,
+            LocatorTypes::Supplement => Locator::Supplement,
+            LocatorTypes::Table => Locator::Table,
+            LocatorTypes::Timestamp => Locator::Timestamp,
+            LocatorTypes::Title => Locator::Title,
+            LocatorTypes::TitleLocator => Locator::TitleLocator,
+            LocatorTypes::Verse => Locator::Verse,
+            LocatorTypes::Volume => Locator::Volume,
+        }
+    }
+}
+
 /// Main function of the Hayagriva CLI.
 fn main() {
     let matches = Command::new("Hayagriva CLI")
@@ -142,6 +212,28 @@ fn main() {
                             .long("locators")
                             .help("Specify additional information for the citations, e.g. \"p. 6,p. 4\", in a comma-separated list.")
                             .num_args(1)
+                    )
+                    .arg(
+                        Arg::new("locator_type")
+                            .long("type")
+                            .help("Specify the type of the locator, e.g. page number, line number, timestamp.")
+                            .value_parser(clap::value_parser!(LocatorTypes))
+                            .hide_possible_values(true)
+                            .long_help(r#"Specify the type of the locator, e.g. page number, line number, timestamp.
+
+Possible values:
+act         appendix        article-locator
+book        canon           chapter
+column      e-location      equation
+figure      folio           issue
+line        note            opus
+page        paragraph       part
+rule        scene           section
+sub-verbo   supplement      table
+timestamp   title           title-locator
+verse       volume"#)
+                            .ignore_case(true)
+                            .num_args(1..)
                     )
                     .arg(
                         Arg::new("combined")
@@ -368,11 +460,15 @@ fn main() {
             let (style, locales, locale) =
                 retrieve_assets(style, csl, locale_path, locale_str);
 
+            let indicated_locator = if let Some(locator_type) = sub_matches.get_one::<LocatorTypes>("locator_type") {
+                locator_type.into()
+            } else { Locator::Custom };
+
             let assign_locator = |(i, e)| {
                 let mut item = CitationItem::with_entry(e);
                 if let Some(&locator) = locators.get(i) {
                     item.locator = Some(SpecificLocator(
-                        Locator::Custom,
+                        indicated_locator,
                         LocatorPayload::Str(locator),
                     ));
                 }


### PR DESCRIPTION
This pull request adds the ability for the user to specify locator type in the CLI through the use of a `--type` flag. Before, the CLI treated all locators as `Locator::Custom` which caused improper formatting for some citation styles, such as MLA. Resolves #492

Change in use:
<pre>
hayagriva cite example.yaml --style mla -k example --locators 8 <strong>--type page</strong>
</pre>
Which would result in `(Example 8)` in contrast to the previous `(Example, 8)`.