### PR TITLE
Fix two container lookups: conference parents and legislation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -804,6 +804,18 @@ impl Entry {
             EntryType::Report => {
                 retrieve_container(&[EntryType::Book, EntryType::Anthology])
             }
+            // A statute is published in an official gazette — a newspaper or a
+            // periodical — and reprinted in collections of law. Without this
+            // arm a `Legislation` had no container at all, so the gazette's
+            // title and volume never reached the style.
+            EntryType::Legislation => retrieve_container(&[
+                EntryType::Newspaper,
+                EntryType::Periodical,
+                EntryType::Anthology,
+                EntryType::Book,
+                EntryType::Reference,
+                EntryType::Web,
+            ]),
             EntryType::Web => retrieve_container(&[EntryType::Web]),
             EntryType::Scene => retrieve_container(&[
                 EntryType::Audio,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,16 +774,20 @@ impl Entry {
         match &self.entry_type {
             EntryType::Article => retrieve_container(&[
                 EntryType::Book,
-                // Proceedings must come before Conference.
-                // Because @inproceedings will result in a Article entry with a Proceedings and a
-                // Conference parent. But only the Proceedings has the correct title.
                 EntryType::Proceedings,
-                EntryType::Conference,
                 EntryType::Periodical,
                 EntryType::Newspaper,
                 EntryType::Blog,
                 EntryType::Reference,
                 EntryType::Web,
+                // Conference comes LAST because it is an event, not a
+                // container: it only stands in as one when the entry has no
+                // real container beside it. `@inproceedings` yields an Article
+                // with both a Proceedings and a Conference parent, and only the
+                // Proceedings carries the container's title; an event published
+                // in a journal yields a Periodical and a Conference, and there
+                // the Periodical is the container.
+                EntryType::Conference,
             ]),
             EntryType::Anthos => retrieve_container(&[
                 EntryType::Book,


### PR DESCRIPTION
Two independent fixes in `Entry::get_container`, both found while rendering
Brazilian ABNT NBR 6023:2025 references through a CSL style. Each is one arm of
the same match, so they are sent together.

### 1. Prefer a real container over a conference parent

`get_container` ranked `Conference` above `Periodical`, `Newspaper`, `Blog`,
`Reference` and `Web` for an `Article`. The ranking exists so that an
`@inproceedings` — which yields an Article with both a `Proceedings` and a
`Conference` parent — takes the `Proceedings`, the one that carries the
container's title.

But it also fires when the sibling is a real container. An event published as an
issue of a journal (an Article with a `Periodical` and a `Conference` parent)
lost the journal's title, and its `volume` with it, to the event's name.

A conference is an event, not a container: it stands in as one only when there
is no real container beside it, so it now comes last. `@inproceedings` is
unaffected — `Proceedings` still outranks it.

### 2. Give legislation a container

`get_container` had no arm for `Legislation`, so a statute published in an
official gazette had no container at all: the gazette's title and volume never
reached the style, and only `issue` survived, because it does not go through
`get_container`. A statute is published in a gazette — a newspaper or a
periodical — and reprinted in collections of law, so those are its containers.

---

`cargo test`, `cargo fmt --check` and `cargo clippy --all-targets` are clean.